### PR TITLE
Migrate backend to PostgreSQL and add Google-gated online profile + music UI enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# --- ba_server ---
+PORT=4000
+CORS_ORIGIN=http://localhost:3000
+POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/baturo_arena
+
+# --- ba_web ---
+NEXT_PUBLIC_BATURO_API_BASE_URL=http://localhost:4000
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-oauth-web-client-id.apps.googleusercontent.com

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Edit files in `/ba_web/src` to update components, features, or styling.
 ## 🛠️ Backend: `ba_server`
 
 - Node.js/Express server with modular architecture
+- PostgreSQL is required for persistence (`POSTGRES_URL`)
 - All REST API logic in `/ba_server/src`:
     - `routes/` – Endpoint definitions
     - `services/` – Business logic
@@ -91,6 +92,12 @@ cd ba_server
 pnpm start
 # runs backend server (port as per config)
 ```
+
+### Environment quick start
+
+1. Copy `.env.example` to `.env`.
+2. Set `POSTGRES_URL` for the API server.
+3. Set `NEXT_PUBLIC_GOOGLE_CLIENT_ID` for Google Sign-In (used for online multiplayer account access).
 
 ---
 

--- a/ba_server/package.json
+++ b/ba_server/package.json
@@ -13,6 +13,6 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
-    "sql.js": "^1.13.0"
+    "pg": "^8.16.0"
   }
 }

--- a/ba_server/src/config/env.js
+++ b/ba_server/src/config/env.js
@@ -1,4 +1,5 @@
 module.exports = {
   port: Number(process.env.PORT || 4000),
-  corsOrigin: process.env.CORS_ORIGIN || "*",
+  corsOrigin: process.env.CORS_ORIGIN || '*',
+  postgresUrl: process.env.POSTGRES_URL || '',
 };

--- a/ba_server/src/db/client.js
+++ b/ba_server/src/db/client.js
@@ -1,98 +1,60 @@
-const fs = require("fs");
-const path = require("path");
-const initSqlJs = require("sql.js");
+const { Pool } = require('pg');
+const { postgresUrl } = require('../config/env');
 
-const dbDirectory = path.join(__dirname, "..", "..", "data");
-const dbPath = path.join(dbDirectory, 'baturo-arena.sqlite');
-const legacyDbPath = path.join(dbDirectory, 'ttt.sqlite');
-
-let SQL = null;
-let db = null;
+let pool = null;
 
 function ensureInitialized() {
-  if (!db) {
-    throw new Error("Database not initialized");
+  if (!pool) {
+    throw new Error('Database not initialized');
   }
 }
 
-function persistDatabase() {
-  ensureInitialized();
-  const data = db.export();
-  fs.writeFileSync(dbPath, Buffer.from(data));
-}
-
-function mapResultRow(statement) {
-  const row = {};
-  const values = statement.get();
-  statement.getColumnNames().forEach((column, index) => {
-    row[column] = values[index];
+function replaceQuestionPlaceholders(sql) {
+  let parameterIndex = 0;
+  return sql.replace(/\?/g, () => {
+    parameterIndex += 1;
+    return `$${parameterIndex}`;
   });
-  return row;
 }
 
 async function initializeClient() {
-  if (db) {
+  if (pool) {
     return;
   }
 
-  if (!fs.existsSync(dbDirectory)) {
-    fs.mkdirSync(dbDirectory, { recursive: true });
+  if (!postgresUrl) {
+    throw new Error('POSTGRES_URL is required');
   }
 
-  SQL = await initSqlJs({
-    locateFile: (file) => path.join(__dirname, "..", "..", "node_modules", "sql.js", "dist", file),
+  pool = new Pool({
+    connectionString: postgresUrl,
   });
 
-  const sourceDbPath = fs.existsSync(dbPath) ? dbPath : legacyDbPath;
-
-  if (fs.existsSync(sourceDbPath)) {
-    const fileBuffer = fs.readFileSync(sourceDbPath);
-    db = new SQL.Database(fileBuffer);
-    if (sourceDbPath !== dbPath) {
-      persistDatabase();
-    }
-  } else {
-    db = new SQL.Database();
-    persistDatabase();
-  }
-
-  db.run("PRAGMA foreign_keys = ON");
+  await pool.query('SELECT 1');
 }
 
 async function run(sql, params = []) {
   ensureInitialized();
-  db.run(sql, params);
+  const result = await pool.query(replaceQuestionPlaceholders(sql), params);
+  const firstRow = result.rows[0] || null;
 
-  const idResult = allSync("SELECT last_insert_rowid() AS id LIMIT 1");
-  const lastID = idResult[0] ? Number(idResult[0].id) : null;
-  const changes = Number(db.getRowsModified());
-
-  persistDatabase();
-
-  return { lastID, changes };
-}
-
-function allSync(sql, params = []) {
-  ensureInitialized();
-
-  const statement = db.prepare(sql, params);
-  const rows = [];
-
-  while (statement.step()) {
-    rows.push(mapResultRow(statement));
-  }
-
-  statement.free();
-  return rows;
+  return {
+    lastID: firstRow && Number.isFinite(Number(firstRow.id)) ? Number(firstRow.id) : null,
+    changes: Number(result.rowCount || 0),
+    rows: result.rows,
+  };
 }
 
 async function get(sql, params = []) {
-  const rows = allSync(sql, params);
-  return rows.length > 0 ? rows[0] : null;
+  ensureInitialized();
+  const result = await pool.query(replaceQuestionPlaceholders(sql), params);
+  return result.rows[0] || null;
 }
 
 async function all(sql, params = []) {
-  return allSync(sql, params);
+  ensureInitialized();
+  const result = await pool.query(replaceQuestionPlaceholders(sql), params);
+  return result.rows;
 }
 
 module.exports = {

--- a/ba_server/src/db/migrations.js
+++ b/ba_server/src/db/migrations.js
@@ -1,8 +1,12 @@
 const { run, all } = require('./client');
 
 async function ensureRoomColumns() {
-  const columns = await all('PRAGMA table_info(rooms)');
-  const columnNames = new Set(columns.map((column) => column.name));
+  const columns = await all(
+    `SELECT column_name
+     FROM information_schema.columns
+     WHERE table_name = 'rooms'`
+  );
+  const columnNames = new Set(columns.map((column) => column.column_name));
 
   if (!columnNames.has('game_type')) {
     await run("ALTER TABLE rooms ADD COLUMN game_type TEXT NOT NULL DEFAULT 'tic-tac-two'");
@@ -21,17 +25,17 @@ async function runMigrations() {
       wins INTEGER NOT NULL DEFAULT 0,
       losses INTEGER NOT NULL DEFAULT 0,
       draws INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
   await run(`
     CREATE TABLE IF NOT EXISTS rooms (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      id BIGSERIAL PRIMARY KEY,
       code TEXT NOT NULL UNIQUE,
       name TEXT NOT NULL,
-      is_public INTEGER NOT NULL DEFAULT 0,
+      is_public BOOLEAN NOT NULL DEFAULT FALSE,
       creator_player_id TEXT NOT NULL,
       game_type TEXT NOT NULL DEFAULT 'tic-tac-two',
       max_players INTEGER NOT NULL DEFAULT 4,
@@ -39,9 +43,9 @@ async function runMigrations() {
       turn TEXT NOT NULL DEFAULT 'X',
       status TEXT NOT NULL DEFAULT 'waiting',
       winner TEXT,
-      result_recorded INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      result_recorded BOOLEAN NOT NULL DEFAULT FALSE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
       FOREIGN KEY (creator_player_id) REFERENCES players(id)
     )
   `);
@@ -50,10 +54,10 @@ async function runMigrations() {
 
   await run(`
     CREATE TABLE IF NOT EXISTS room_players (
-      room_id INTEGER NOT NULL,
+      room_id BIGINT NOT NULL,
       player_id TEXT NOT NULL,
       symbol TEXT NOT NULL,
-      joined_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      joined_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
       PRIMARY KEY (room_id, player_id),
       FOREIGN KEY (room_id) REFERENCES rooms(id) ON DELETE CASCADE,
       FOREIGN KEY (player_id) REFERENCES players(id)
@@ -67,16 +71,17 @@ async function runMigrations() {
       wins INTEGER NOT NULL DEFAULT 0,
       losses INTEGER NOT NULL DEFAULT 0,
       draws INTEGER NOT NULL DEFAULT 0,
-      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
       PRIMARY KEY (player_id, game_type),
       FOREIGN KEY (player_id) REFERENCES players(id) ON DELETE CASCADE
     )
   `);
 
   await run(`
-    INSERT OR IGNORE INTO player_game_stats (player_id, game_type, wins, losses, draws, updated_at)
+    INSERT INTO player_game_stats (player_id, game_type, wins, losses, draws, updated_at)
     SELECT id, 'tic-tac-two', wins, losses, draws, CURRENT_TIMESTAMP
     FROM players
+    ON CONFLICT (player_id, game_type) DO NOTHING
   `);
 }
 

--- a/ba_server/src/repositories/roomRepository.js
+++ b/ba_server/src/repositories/roomRepository.js
@@ -20,8 +20,9 @@ async function createRoom({ code, name, isPublic, creatorPlayerId, gameType, max
   const insertResult = await run(
     `INSERT INTO rooms (
       code, name, is_public, creator_player_id, game_type, max_players, board, turn, status, winner, result_recorded, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'X', 'waiting', NULL, 0, CURRENT_TIMESTAMP)`,
-    [code, name, isPublic ? 1 : 0, creatorPlayerId, gameType, maxPlayers, emptyBoard]
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'X', 'waiting', NULL, FALSE, CURRENT_TIMESTAMP)
+    RETURNING id`,
+    [code, name, isPublic, creatorPlayerId, gameType, maxPlayers, emptyBoard]
   );
   return getRoomById(insertResult.lastID);
 }
@@ -48,7 +49,7 @@ async function listPublicRooms() {
       COUNT(rp.player_id) AS players_count
     FROM rooms r
     LEFT JOIN room_players rp ON rp.room_id = r.id
-    WHERE r.is_public = 1
+    WHERE r.is_public = TRUE
     GROUP BY r.id
     ORDER BY r.created_at DESC`
   );
@@ -66,8 +67,9 @@ async function listPublicRooms() {
 
 async function addPlayerToRoom(roomId, playerId, symbol) {
   await run(
-    `INSERT OR IGNORE INTO room_players (room_id, player_id, symbol)
-     VALUES (?, ?, ?)`,
+    `INSERT INTO room_players (room_id, player_id, symbol)
+     VALUES (?, ?, ?)
+     ON CONFLICT (room_id, player_id) DO NOTHING`,
     [roomId, playerId, symbol]
   );
 }
@@ -102,7 +104,7 @@ async function updateRoomState(roomId, { board, turn, status, winner, resultReco
     `UPDATE rooms
      SET board = ?, turn = ?, status = ?, winner = ?, result_recorded = ?, updated_at = CURRENT_TIMESTAMP
      WHERE id = ?`,
-    [JSON.stringify(board), turn, status, winner, resultRecorded ? 1 : 0, roomId]
+    [JSON.stringify(board), turn, status, winner, resultRecorded, roomId]
   );
 }
 
@@ -114,7 +116,7 @@ async function resetRoom(roomId, status) {
 
   await run(
     `UPDATE rooms
-     SET board = ?, turn = 'X', status = ?, winner = NULL, result_recorded = 0, updated_at = CURRENT_TIMESTAMP
+     SET board = ?, turn = 'X', status = ?, winner = NULL, result_recorded = FALSE, updated_at = CURRENT_TIMESTAMP
      WHERE id = ?`,
     [JSON.stringify(createEmptyBoard(room.game_type)), status, roomId]
   );

--- a/ba_web/src/app/globals.css
+++ b/ba_web/src/app/globals.css
@@ -1149,12 +1149,20 @@ h1 span:last-child {
   margin-bottom: 0.5rem;
 }
 
-.music-dock {
+.dock-launchers {
   position: fixed;
   top: 50%;
   right: 0;
   transform: translateY(-50%);
   z-index: 92;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.music-dock,
+.profile-dock {
+  position: relative;
   pointer-events: none;
 }
 
@@ -1175,6 +1183,16 @@ h1 span:last-child {
   font-size: 1.95rem;
   box-shadow: -6px 8px 20px rgba(0, 0, 0, 0.35);
   transition: filter 150ms ease, transform 150ms ease;
+}
+
+.music-dock-toggle-profile {
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.28), transparent 64%),
+    linear-gradient(160deg, rgba(54, 22, 79, 0.94), rgba(27, 71, 114, 0.92));
+}
+
+.music-dock-toggle-active {
+  filter: brightness(1.08);
 }
 
 .music-dock-toggle:hover {
@@ -1202,6 +1220,91 @@ h1 span:last-child {
   color: #111;
   box-shadow: -10px 12px 26px rgba(0, 0, 0, 0.26);
   transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.profile-dock-panel {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%) translateX(108%);
+  opacity: 0;
+  pointer-events: none;
+  width: min(90vw, 300px);
+  border: 4px solid #000;
+  border-right: 0;
+  border-radius: 16px 0 0 16px;
+  padding: 0.7rem;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 58%),
+    linear-gradient(155deg, rgba(250, 250, 250, 0.92), rgba(227, 235, 250, 0.86));
+  color: #111;
+  box-shadow: -10px 12px 26px rgba(0, 0, 0, 0.26);
+  transition: transform 220ms ease, opacity 220ms ease;
+}
+
+.profile-dock-open .profile-dock-panel {
+  transform: translateY(-50%) translateX(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.profile-dock-account {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  text-align: center;
+}
+
+.profile-dock-avatar {
+  width: 88px;
+  height: 88px;
+  border: 3px solid #000;
+  border-radius: 999px;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.profile-dock-avatar-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+}
+
+.profile-dock-auth-btn {
+  margin-top: 0.2rem;
+}
+
+.music-now-playing-toast {
+  position: fixed;
+  left: 0.8rem;
+  bottom: 0.8rem;
+  z-index: 95;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: 3px solid #000;
+  border-radius: 12px;
+  padding: 0.45rem 0.6rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  text-shadow: none;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
+}
+
+.music-now-playing-toast img {
+  width: 52px;
+  height: 52px;
+  border-radius: 8px;
+  border: 2px solid #000;
+  object-fit: cover;
+}
+
+.music-now-playing-toast div {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
 }
 
 .music-dock-open .music-dock-panel {

--- a/ba_web/src/app/page.tsx
+++ b/ba_web/src/app/page.tsx
@@ -13,6 +13,7 @@ import { LeaderboardScreen } from '@/features/home/LeaderboardScreen';
 import { LobbyScreen } from '@/features/home/LobbyScreen';
 import { MainMenu } from '@/features/home/MainMenu';
 import { MusicDock, type MusicTrack } from '@/features/home/MusicDock';
+import { ProfileDock, type GoogleAccount } from '@/features/home/ProfileDock';
 import { SettingsScreen } from '@/features/home/SettingsScreen';
 import { useApiClient } from '@/hooks/useApiClient';
 import { STORAGE_KEYS } from '@/lib/constants';
@@ -49,6 +50,24 @@ type LocalBackupPayload = {
   enableAnimations: boolean;
   cpuDifficulty: CpuDifficulty;
 };
+
+type GoogleCredentialResponse = {
+  credential?: string;
+};
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        id?: {
+          initialize: (config: { client_id: string; callback: (response: GoogleCredentialResponse) => void }) => void;
+          prompt: () => void;
+          cancel: () => void;
+        };
+      };
+    };
+  }
+}
 
 const clampChannel = (value: number): number => Math.max(0, Math.min(255, Math.round(value)));
 
@@ -190,6 +209,8 @@ export default function Home() {
   const [showSaveTip, setShowSaveTip] = useState(false);
   const [dontShowSaveTipAgain, setDontShowSaveTipAgain] = useState(false);
   const [matchHistory, setMatchHistory] = useState<MatchHistoryEntry[]>([]);
+  const [googleAccount, setGoogleAccount] = useState<GoogleAccount | null>(null);
+  const [isProfileDockOpen, setIsProfileDockOpen] = useState(false);
   const saveIndicatorTimeoutRef = useRef<number | null>(null);
 
   const { activeRequests, runWithLoader, callApi } = useApiClient();
@@ -221,6 +242,91 @@ export default function Home() {
       saveIndicatorTimeoutRef.current = null;
     }, 1800);
   }, []);
+
+  const decodeJwtPayload = (credential: string): GoogleAccount | null => {
+    const jwtParts = credential.split('.');
+    if (jwtParts.length < 2) {
+      return null;
+    }
+
+    try {
+      const payload = JSON.parse(atob(jwtParts[1].replace(/-/g, '+').replace(/_/g, '/')));
+      if (!payload || typeof payload.sub !== 'string' || typeof payload.name !== 'string') {
+        return null;
+      }
+
+      return {
+        sub: payload.sub,
+        name: payload.name,
+        email: typeof payload.email === 'string' ? payload.email : undefined,
+        picture: typeof payload.picture === 'string' ? payload.picture : undefined,
+      };
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  const saveGoogleAccount = useCallback((account: GoogleAccount | null) => {
+    setGoogleAccount(account);
+    if (!account) {
+      window.localStorage.removeItem(STORAGE_KEYS.googleAccount);
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEYS.googleAccount, JSON.stringify(account));
+  }, []);
+
+  const startGoogleSignIn = useCallback(() => {
+    const googleClientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+    if (!googleClientId) {
+      setMessage('Missing NEXT_PUBLIC_GOOGLE_CLIENT_ID in frontend env');
+      return;
+    }
+
+    if (!window.google?.accounts?.id) {
+      setMessage('Google Sign-In script is not ready yet. Try again in a second.');
+      return;
+    }
+
+    window.google.accounts.id.initialize({
+      client_id: googleClientId,
+      callback: (response: GoogleCredentialResponse) => {
+        if (!response.credential) {
+          setMessage('Google sign-in did not return credentials');
+          return;
+        }
+
+        const parsedAccount = decodeJwtPayload(response.credential);
+        if (!parsedAccount) {
+          setMessage('Could not read Google account details');
+          return;
+        }
+
+        saveGoogleAccount(parsedAccount);
+        setPlayerName(parsedAccount.name);
+        window.localStorage.setItem(STORAGE_KEYS.playerName, parsedAccount.name);
+        setMessage('Google account connected');
+      },
+    });
+
+    window.google.accounts.id.prompt();
+  }, [saveGoogleAccount]);
+
+  const signOutGoogle = useCallback(() => {
+    if (window.google?.accounts?.id) {
+      window.google.accounts.id.cancel();
+    }
+    saveGoogleAccount(null);
+    setMessage('Signed out from Google account');
+  }, [saveGoogleAccount]);
+
+  const requireGoogleAccountForOnline = useCallback((): GoogleAccount | null => {
+    if (googleAccount) {
+      return googleAccount;
+    }
+    setMessage('Sign in with Google to access online multiplayer. CPU and solo play do not need an account.');
+    setIsProfileDockOpen(true);
+    return null;
+  }, [googleAccount]);
 
   const parseLocalBackup = (rawValue: string | null): LocalBackupPayload | null => {
     if (!rawValue) {
@@ -484,13 +590,13 @@ export default function Home() {
     [availableGames]
   );
 
-  const ensurePlayer = async () => {
-    const savedPlayerId = window.localStorage.getItem(STORAGE_KEYS.playerId);
+  const ensurePlayer = async (identity?: { playerId: string; name: string }) => {
+    const savedPlayerId = identity?.playerId || window.localStorage.getItem(STORAGE_KEYS.playerId);
     const payload = await callApi<PlayerProfile>('/api/players/register', {
       method: 'POST',
       body: JSON.stringify({
         playerId: savedPlayerId,
-        name: playerName || 'Player',
+        name: identity?.name || playerName || 'Player',
       }),
     });
 
@@ -518,7 +624,14 @@ export default function Home() {
 
     try {
       setIsLoading(true);
-      const registeredPlayer = await ensurePlayer();
+      const onlineAccount = requireGoogleAccountForOnline();
+      if (!onlineAccount) {
+        return;
+      }
+      const registeredPlayer = await ensurePlayer({
+        playerId: `google:${onlineAccount.sub}`,
+        name: onlineAccount.name,
+      });
 
       const payload = await callApi<RoomPayload>('/api/rooms', {
         method: 'POST',
@@ -553,7 +666,14 @@ export default function Home() {
 
     try {
       setIsLoading(true);
-      const registeredPlayer = await ensurePlayer();
+      const onlineAccount = requireGoogleAccountForOnline();
+      if (!onlineAccount) {
+        return;
+      }
+      const registeredPlayer = await ensurePlayer({
+        playerId: `google:${onlineAccount.sub}`,
+        name: onlineAccount.name,
+      });
 
       const payload = await callApi<RoomPayload>('/api/rooms/join', {
         method: 'POST',
@@ -604,6 +724,7 @@ export default function Home() {
     const savedAnimations = window.localStorage.getItem(STORAGE_KEYS.enableAnimations);
     const savedDifficulty = window.localStorage.getItem(STORAGE_KEYS.cpuDifficulty);
     const savedPreferredGame = window.localStorage.getItem(STORAGE_KEYS.preferredGame);
+    const savedGoogleAccount = window.localStorage.getItem(STORAGE_KEYS.googleAccount);
 
     if (savedName) {
       setPlayerName(savedName);
@@ -622,6 +743,17 @@ export default function Home() {
     }
     if (savedDifficulty === 'easy' || savedDifficulty === 'medium' || savedDifficulty === 'hard') {
       setCpuDifficulty(savedDifficulty);
+    }
+    if (savedGoogleAccount) {
+      try {
+        const parsedGoogle = JSON.parse(savedGoogleAccount) as GoogleAccount;
+        if (parsedGoogle?.sub && parsedGoogle?.name) {
+          setGoogleAccount(parsedGoogle);
+          setPlayerName(parsedGoogle.name);
+        }
+      } catch (_error) {
+        // ignore malformed saved account
+      }
     }
     if (savedPreferredGame) {
       const normalizedPreferredGame = normalizeGameType(savedPreferredGame);
@@ -651,15 +783,31 @@ export default function Home() {
     const shouldHideSaveTip = window.localStorage.getItem(STORAGE_KEYS.hideSaveTip);
     setShowSaveTip(shouldHideSaveTip !== 'true');
 
-    ensurePlayer().catch(() => {
-      // Registration can be retried from UI.
-    });
     refreshPublicRooms().catch(() => {
       // Ignore initial lobby load failures.
     });
     refreshLeaderboard().catch(() => {
       // Ignore initial leaderboard load failures.
     });
+  }, []);
+
+  useEffect(() => {
+    if (document.querySelector('script[data-google-identity]')) {
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = 'https://accounts.google.com/gsi/client';
+    script.async = true;
+    script.defer = true;
+    script.dataset.googleIdentity = 'true';
+    document.body.appendChild(script);
+
+    return () => {
+      if (script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -920,7 +1068,7 @@ export default function Home() {
       {showSaveTip ? (
         <div className="save-tip-card">
           <p>
-            Arena stats can reset after redeploy. Go to Settings any time to load your local save backup for your current Baturo Arena lineup.
+            Backups are local-only right now. Use Settings to save or load this device backup for your Baturo Arena lineup.
           </p>
           <label className="save-tip-check">
             <input type="checkbox" checked={dontShowSaveTipAgain} onChange={(event) => setDontShowSaveTipAgain(event.target.checked)} />
@@ -940,20 +1088,30 @@ export default function Home() {
           </button>
         </div>
       ) : null}
-      <MusicDock
-        tracks={APP_MUSIC_TRACKS}
-        isMuted={isMusicMuted}
-        volume={musicVolume}
-        onToggleMute={() => {
-          const nextValue = !isMusicMuted;
-          setIsMusicMuted(nextValue);
-          window.localStorage.setItem(STORAGE_KEYS.musicMuted, String(nextValue));
-        }}
-        onVolumeChange={(volume) => {
-          setMusicVolume(volume);
-          window.localStorage.setItem(STORAGE_KEYS.musicVolume, String(volume));
-        }}
-      />
+      <div className="dock-launchers">
+        <ProfileDock
+          isOpen={isProfileDockOpen}
+          account={googleAccount}
+          onToggleOpen={() => setIsProfileDockOpen((currentValue) => !currentValue)}
+          onSignIn={startGoogleSignIn}
+          onSignOut={signOutGoogle}
+        />
+        <MusicDock
+          tracks={APP_MUSIC_TRACKS}
+          isMuted={isMusicMuted}
+          volume={musicVolume}
+          showLauncher={!isProfileDockOpen}
+          onToggleMute={() => {
+            const nextValue = !isMusicMuted;
+            setIsMusicMuted(nextValue);
+            window.localStorage.setItem(STORAGE_KEYS.musicMuted, String(nextValue));
+          }}
+          onVolumeChange={(volume) => {
+            setMusicVolume(volume);
+            window.localStorage.setItem(STORAGE_KEYS.musicVolume, String(volume));
+          }}
+        />
+      </div>
       {!isInMatch ? <span className="fixed bottom-1 text-sm">Project By AJ4200 c 2023</span> : null}
     </main>
   );

--- a/ba_web/src/features/home/MusicDock.tsx
+++ b/ba_web/src/features/home/MusicDock.tsx
@@ -38,6 +38,7 @@ type MusicDockProps = {
   tracks: MusicTrack[];
   isMuted: boolean;
   volume: number;
+  showLauncher?: boolean;
   onToggleMute: () => void;
   onVolumeChange: (volume: number) => void;
 };
@@ -55,7 +56,7 @@ const formatClock = (seconds: number): string => {
   return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
 };
 
-export function MusicDock({ tracks, isMuted, volume, onToggleMute, onVolumeChange }: MusicDockProps) {
+export function MusicDock({ tracks, isMuted, volume, showLauncher = true, onToggleMute, onVolumeChange }: MusicDockProps) {
   const hasTracks = tracks.length > 0;
   const [isOpen, setIsOpen] = useState(false);
   const [isTrackListOpen, setIsTrackListOpen] = useState(false);
@@ -66,6 +67,8 @@ export function MusicDock({ tracks, isMuted, volume, onToggleMute, onVolumeChang
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
   const [isAdjustingVolume, setIsAdjustingVolume] = useState(false);
+  const [nowPlayingToast, setNowPlayingToast] = useState<MusicTrack | null>(null);
+  const lastToastTrackIdRef = useRef<string | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const volumeKnobRef = useRef<HTMLDivElement | null>(null);
   const safeVolume = Math.min(100, Math.max(0, Math.round(volume)));
@@ -146,6 +149,29 @@ export function MusicDock({ tracks, isMuted, volume, onToggleMute, onVolumeChang
     audio.load();
     tryPlay();
   }, [activeTrack?.src, tryPlay]);
+
+  useEffect(() => {
+    if (!activeTrack) {
+      setNowPlayingToast(null);
+      lastToastTrackIdRef.current = null;
+      return;
+    }
+
+    if (lastToastTrackIdRef.current === null) {
+      lastToastTrackIdRef.current = activeTrack.id;
+      return;
+    }
+
+    if (lastToastTrackIdRef.current === activeTrack.id) {
+      return;
+    }
+
+    lastToastTrackIdRef.current = activeTrack.id;
+    setNowPlayingToast(activeTrack);
+
+    const timeoutId = window.setTimeout(() => setNowPlayingToast(null), 3000);
+    return () => window.clearTimeout(timeoutId);
+  }, [activeTrack]);
 
   const pickRandomTrackIndex = useCallback(
     (excludeIndex: number): number => {
@@ -328,7 +354,7 @@ export function MusicDock({ tracks, isMuted, volume, onToggleMute, onVolumeChang
 
   return (
     <div className={classnames('music-dock', isOpen && 'music-dock-open')}>
-      {!isOpen ? (
+      {!isOpen && showLauncher ? (
         <button
           className="music-dock-toggle"
           type="button"
@@ -537,6 +563,17 @@ export function MusicDock({ tracks, isMuted, volume, onToggleMute, onVolumeChang
         onTimeUpdate={(event) => setCurrentTime(event.currentTarget.currentTime)}
         onLoadedMetadata={(event) => setDuration(event.currentTarget.duration || 0)}
       />
+
+      {nowPlayingToast ? (
+        <div className="music-now-playing-toast" role="status" aria-live="polite">
+          <img src={nowPlayingToast.artSrc || GENERIC_ART_SRC} alt={`${nowPlayingToast.title} art`} />
+          <div>
+            <strong>Now Playing</strong>
+            <span>{nowPlayingToast.title}</span>
+            <small>{nowPlayingToast.artist}</small>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ba_web/src/features/home/ProfileDock.tsx
+++ b/ba_web/src/features/home/ProfileDock.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import classnames from 'classnames';
+import { AiOutlineClose, AiOutlineLogin, AiOutlineLogout, AiOutlineUser } from 'react-icons/ai';
+
+export type GoogleAccount = {
+  sub: string;
+  name: string;
+  email?: string;
+  picture?: string;
+};
+
+type ProfileDockProps = {
+  isOpen: boolean;
+  account: GoogleAccount | null;
+  onToggleOpen: () => void;
+  onSignIn: () => void;
+  onSignOut: () => void;
+};
+
+export function ProfileDock({ isOpen, account, onToggleOpen, onSignIn, onSignOut }: ProfileDockProps) {
+  return (
+    <div className={classnames('profile-dock', isOpen && 'profile-dock-open')}>
+      <button
+        className={classnames('music-dock-toggle', 'music-dock-toggle-profile', isOpen && 'music-dock-toggle-active')}
+        type="button"
+        onClick={onToggleOpen}
+        aria-label={isOpen ? 'Hide profile panel' : 'Show profile panel'}
+      >
+        <AiOutlineUser />
+      </button>
+
+      <section className="profile-dock-panel" aria-hidden={!isOpen}>
+        <header className="music-dock-head">
+          <h3>Profile</h3>
+          <button className="music-dock-head-btn" type="button" onClick={onToggleOpen} aria-label="Close profile panel">
+            <AiOutlineClose />
+          </button>
+        </header>
+
+        {account ? (
+          <div className="profile-dock-account">
+            <img src={account.picture || '/music/art/generic-cover.svg'} alt={`${account.name} avatar`} className="profile-dock-avatar" />
+            <strong>{account.name}</strong>
+            <span>{account.email || 'Google account connected'}</span>
+            <button className={classnames('lobby-btn', 'custome-shadow', 'profile-dock-auth-btn')} type="button" onClick={onSignOut}>
+              <AiOutlineLogout /> Sign out
+            </button>
+          </div>
+        ) : (
+          <div className="profile-dock-account">
+            <div className="profile-dock-avatar profile-dock-avatar-placeholder">
+              <AiOutlineUser />
+            </div>
+            <strong>Guest mode</strong>
+            <span>Google sign-in is required only for online multiplayer.</span>
+            <button className={classnames('lobby-btn', 'custome-shadow', 'profile-dock-auth-btn')} type="button" onClick={onSignIn}>
+              <AiOutlineLogin /> Sign in with Google
+            </button>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ba_web/src/features/home/SettingsScreen.tsx
+++ b/ba_web/src/features/home/SettingsScreen.tsx
@@ -93,7 +93,7 @@ export function SettingsScreen({
         </div>
 
         <div className="settings-item settings-item-save">
-          <p>Cloud Reset Backup</p>
+          <p>Local Backup</p>
           <div className="settings-save-actions">
             <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onSaveNow}>
               Save Now

--- a/ba_web/src/lib/constants.ts
+++ b/ba_web/src/lib/constants.ts
@@ -15,4 +15,5 @@ export const STORAGE_KEYS = {
   localBackup: 'baruto_local_backup_v2',
   matchHistory: 'baruto_match_history_v2',
   hideSaveTip: 'baruto_hide_save_tip',
+  googleAccount: 'baruto_google_account_v1',
 };


### PR DESCRIPTION
### Motivation
- Replace the in-memory/sqlite persistence with a real Postgres backend for durable server storage and easier deployment configuration. 
- Require an authenticated Google account only for online multiplayer while keeping CPU and single-player modes account-free. 
- Improve UX by reusing the music-player launcher area to host a profile panel and show a brief bottom-left “Now Playing” toast when tracks change, and provide an example `.env` for required secrets.

### Description
- Backend: replaced `sql.js` usage with `pg` in `ba_server/src/db/client.js`, added `POSTGRES_URL` wiring in `ba_server/src/config/env.js`, and adapted parameter placeholders (`?` -> `$n`) and result handling for Postgres semantics. 
- Migrations & repositories: updated `ba_server/src/db/migrations.js` and `ba_server/src/repositories/roomRepository.js` for Postgres types/keywords (`BOOLEAN`, `BIGSERIAL`, `TIMESTAMPTZ`, `ON CONFLICT DO NOTHING`, `RETURNING id`, etc.). 
- Frontend: integrated Google Sign-In handling and JWT payload decoding in `ba_web/src/app/page.tsx`, added a `ProfileDock` component at `ba_web/src/features/home/ProfileDock.tsx`, and gated `createRoom`/`joinRoom` online flows to require the Google account while leaving CPU/solo flows unchanged. 
- UI/UX: grouped profile + music launchers into `.dock-launchers` (moved music half-circle), added a transient bottom-left `Now Playing` toast in `MusicDock` and related CSS in `ba_web/src/app/globals.css`, and adjusted Settings copy to `Local Backup`. 
- Config & docs: added `.env.example` showing `POSTGRES_URL` and `NEXT_PUBLIC_GOOGLE_CLIENT_ID`, updated `README.md` with environment quick-start, and updated `ba_server/package.json` to depend on `pg`.

### Testing
- Per agent rules, no full test/lint/typecheck suite was run; targeted syntax checks were performed by running `node -c` on modified backend modules and they succeeded for `ba_server/src/db/client.js`, `ba_server/src/db/migrations.js`, `ba_server/src/config/env.js`, and `ba_server/src/repositories/roomRepository.js`. 
- No automated UI or end-to-end tests were executed in this rollout. 
- Next recommended steps: run dependency install (to fetch `pg`) and run the app against a Postgres instance (set `POSTGRES_URL`) and configure `NEXT_PUBLIC_GOOGLE_CLIENT_ID` to validate end-to-end Google sign-in and online room flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce67b80488832596fede7add6d2ea9)