### PR TITLE
Fix now-playing toast anchoring to viewport

### DIFF
--- a/ba_web/src/features/home/MusicDock.tsx
+++ b/ba_web/src/features/home/MusicDock.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import classnames from 'classnames';
 import {
   AiOutlineClose,
@@ -68,6 +69,7 @@ export function MusicDock({ tracks, isMuted, volume, showLauncher = true, onTogg
   const [duration, setDuration] = useState(0);
   const [isAdjustingVolume, setIsAdjustingVolume] = useState(false);
   const [nowPlayingToast, setNowPlayingToast] = useState<MusicTrack | null>(null);
+  const [isClient, setIsClient] = useState(false);
   const lastToastTrackIdRef = useRef<string | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const volumeKnobRef = useRef<HTMLDivElement | null>(null);
@@ -89,6 +91,10 @@ export function MusicDock({ tracks, isMuted, volume, showLauncher = true, onTogg
     '--music-knob-sweep': `${knobSweep}deg`,
   } as CSSProperties;
   const isTrackListPanelOpen = isOpen && isTrackListOpen;
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
   useEffect(() => {
     if (!hasTracks) {
@@ -564,16 +570,19 @@ export function MusicDock({ tracks, isMuted, volume, showLauncher = true, onTogg
         onLoadedMetadata={(event) => setDuration(event.currentTarget.duration || 0)}
       />
 
-      {nowPlayingToast ? (
-        <div className="music-now-playing-toast" role="status" aria-live="polite">
-          <img src={nowPlayingToast.artSrc || GENERIC_ART_SRC} alt={`${nowPlayingToast.title} art`} />
-          <div>
-            <strong>Now Playing</strong>
-            <span>{nowPlayingToast.title}</span>
-            <small>{nowPlayingToast.artist}</small>
-          </div>
-        </div>
-      ) : null}
+      {isClient && nowPlayingToast
+        ? createPortal(
+            <div className="music-now-playing-toast" role="status" aria-live="polite">
+              <img src={nowPlayingToast.artSrc || GENERIC_ART_SRC} alt={`${nowPlayingToast.title} art`} />
+              <div>
+                <strong>Now Playing</strong>
+                <span>{nowPlayingToast.title}</span>
+                <small>{nowPlayingToast.artist}</small>
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The floating "Now Playing" toast was affected by the transformed dock container and did not remain anchored to the viewport bottom-left as intended.
- Move the toast out of the transformed DOM context so `position: fixed` behaves relative to the viewport.

### Description
- Render the now-playing UI through a React portal by importing `createPortal` and mounting the toast into `document.body` instead of the dock container.
- Add a small client-side guard state (`isClient`) and set it in a `useEffect` to avoid accessing `document` during server rendering.
- Replace the inline toast markup with a `createPortal(...)` call that conditionally mounts when `isClient && nowPlayingToast`.

### Testing
- No automated tests were run for this change (per repository `AGENTS.md` guidance).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6b0b3d208325b75536da921b57c7)