### PR TITLE
Integrate lobby player cards and game info with DB-backed metadata

### DIFF
--- a/ba_server/src/repositories/roomRepository.js
+++ b/ba_server/src/repositories/roomRepository.js
@@ -46,11 +46,29 @@ async function listPublicRooms() {
       r.max_players,
       r.status,
       r.is_public,
-      COUNT(rp.player_id) AS players_count
+      creator.name AS creator_name,
+      r.updated_at,
+      COUNT(rp.player_id) AS players_count,
+      COALESCE(
+        JSON_AGG(
+          JSON_BUILD_OBJECT(
+            'playerId', joined_player.id,
+            'name', joined_player.name,
+            'symbol', rp.symbol,
+            'wins', joined_player.wins,
+            'losses', joined_player.losses,
+            'draws', joined_player.draws
+          )
+          ORDER BY rp.joined_at ASC
+        ) FILTER (WHERE rp.player_id IS NOT NULL),
+        '[]'::JSON
+      ) AS players
     FROM rooms r
+    INNER JOIN players creator ON creator.id = r.creator_player_id
     LEFT JOIN room_players rp ON rp.room_id = r.id
+    LEFT JOIN players joined_player ON joined_player.id = rp.player_id
     WHERE r.is_public = TRUE
-    GROUP BY r.id
+    GROUP BY r.id, creator.name
     ORDER BY r.created_at DESC`
   );
 
@@ -62,6 +80,9 @@ async function listPublicRooms() {
     status: row.status,
     isPublic: Boolean(row.is_public),
     playersCount: Number(row.players_count),
+    creatorName: row.creator_name,
+    updatedAt: row.updated_at,
+    players: Array.isArray(row.players) ? row.players : [],
   }));
 }
 

--- a/ba_web/src/app/page.tsx
+++ b/ba_web/src/app/page.tsx
@@ -909,6 +909,7 @@ export default function Home() {
           cpuDifficulty={cpuDifficulty}
           games={availableGames}
           publicRooms={publicRooms}
+          playerProfile={player}
           message={message}
           isLoading={isLoading}
           onClearMessage={() => setMessage('')}

--- a/ba_web/src/features/home/LobbyScreen.tsx
+++ b/ba_web/src/features/home/LobbyScreen.tsx
@@ -10,9 +10,9 @@ import {
   AiOutlineRobot,
   AiOutlineTeam,
 } from 'react-icons/ai';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { formatGameName } from '@/lib/games';
-import type { CpuDifficulty, GameDefinition, GameType, PublicRoom } from '@/types/game';
+import type { CpuDifficulty, GameDefinition, GameType, PlayerProfile, PublicRoom } from '@/types/game';
 
 type LobbyScreenProps = {
   playerName: string;
@@ -22,6 +22,7 @@ type LobbyScreenProps = {
   cpuDifficulty: CpuDifficulty;
   games: GameDefinition[];
   publicRooms: PublicRoom[];
+  playerProfile: PlayerProfile | null;
   message: string;
   isLoading: boolean;
   onClearMessage: () => void;
@@ -48,6 +49,7 @@ export function LobbyScreen({
   cpuDifficulty,
   games,
   publicRooms,
+  playerProfile,
   message,
   isLoading,
   onClearMessage,
@@ -146,6 +148,13 @@ export function LobbyScreen({
         return leftRoom.name.localeCompare(rightRoom.name);
       });
   }, [gameRooms, roomQuery, roomStatusFilter]);
+  const formatUpdatedTime = useCallback((isoDate: string) => {
+    const parsed = new Date(isoDate);
+    if (Number.isNaN(parsed.getTime())) {
+      return 'Unknown update';
+    }
+    return parsed.toLocaleString();
+  }, []);
 
   const handleCopyRoomCode = async (code: string) => {
     try {
@@ -273,11 +282,18 @@ export function LobbyScreen({
                   className="lobby-profile-avatar"
                 />
               </div>
-              <div className="lobby-profile-meta">
-                <strong>{profilePreviewName}</strong>
-                <span>Live avatar preview</span>
-              </div>
+            <div className="lobby-profile-meta">
+              <strong>{profilePreviewName}</strong>
+              <span>{playerProfile ? `Player ID: ${playerProfile.playerId}` : 'Live avatar preview'}</span>
             </div>
+            </div>
+            {playerProfile ? (
+              <div className="public-room-summary">
+                <span className="public-room-pill">Wins {playerProfile.wins}</span>
+                <span className="public-room-pill">Losses {playerProfile.losses}</span>
+                <span className="public-room-pill">Draws {playerProfile.draws}</span>
+              </div>
+            ) : null}
             <div className="lobby-row">
               <input
                 className="lobby-input"
@@ -501,6 +517,8 @@ export function LobbyScreen({
                       <AiOutlineTeam /> {roomItem.playersCount}/{roomItem.maxPlayers} players
                     </span>
                     <span className="public-room-meta-pill">{formatGameName(roomItem.gameType, games)}</span>
+                    <span className="public-room-meta-pill">Host {roomItem.creatorName}</span>
+                    <span className="public-room-meta-pill">Updated {formatUpdatedTime(roomItem.updatedAt)}</span>
                     <span className="public-room-meta-pill public-room-code-pill">
                       Code <span className="public-room-code-badge">{roomItem.code}</span>
                     </span>
@@ -515,6 +533,16 @@ export function LobbyScreen({
                     </button>
                     {copiedRoomCode === roomItem.code ? <span className="room-code-copy-feedback">Copied</span> : null}
                   </div>
+                  {roomItem.players.length > 0 ? (
+                    <div className="public-room-meta">
+                      {roomItem.players.map((joinedPlayer) => (
+                        <span key={`${roomItem.code}-${joinedPlayer.playerId}`} className="public-room-meta-pill">
+                          {joinedPlayer.symbol} · {joinedPlayer.name} ({joinedPlayer.wins}-{joinedPlayer.losses}-
+                          {joinedPlayer.draws})
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
                 </div>
                 <button
                   className={classnames(

--- a/ba_web/src/types/game.ts
+++ b/ba_web/src/types/game.ts
@@ -77,6 +77,16 @@ export type PublicRoom = {
   playersCount: number;
   maxPlayers: number;
   isPublic: boolean;
+  creatorName: string;
+  updatedAt: string;
+  players: Array<{
+    playerId: string;
+    name: string;
+    symbol: 'X' | 'O';
+    wins: number;
+    losses: number;
+    draws: number;
+  }>;
 };
 
 export type LeaderboardPlayer = PlayerProfile & {


### PR DESCRIPTION
### Motivation
- Surface authoritative room and player metadata from the new database in the lobby UI so public room cards and the profile preview reflect persisted host and player stats.

### Description
- Extended `listPublicRooms` in `ba_server/src/repositories/roomRepository.js` to return `creator_name`, `updated_at`, an aggregated `players` JSON array (joined player summaries with symbol and W/L/D), and included the fields in the repository response mapping.
- Expanded frontend `PublicRoom` type in `ba_web/src/types/game.ts` to model `creatorName`, `updatedAt`, and the `players` array so the UI can consume the new metadata safely.
- Passed the current `player` profile from `ba_web/src/app/page.tsx` into `LobbyScreen` as `playerProfile` and updated the `LobbyScreen` props and imports accordingly.
- Updated `ba_web/src/features/home/LobbyScreen.tsx` to display the registered player's stats in the profile panel and to show host name, last-updated timestamp, and joined-player stat chips on public room cards, plus a small `formatUpdatedTime` helper and `useCallback` import.

### Testing
- No automated tests, linters, or type-checks were run for this change (per repository AGENTS.md guidance).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce6c10f8d08325997d943b788030bc)