### PR TITLE
Use pg Pool for Postgres connections and improve SSL/connection handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ pnpm start
 7. Optional DB resilience vars: `DB_CONNECTION_TIMEOUT_MS`, `DB_CONNECT_RETRIES`, `DB_CONNECT_RETRY_DELAY_MS`, `DB_POOL_MAX`.
 8. Optional DB startup retry var: `DB_INIT_RETRY_DELAY_MS` (milliseconds between startup retries when DB is temporarily unavailable).
 9. For Google Sign-In, add each frontend origin you use (for example `http://localhost:3000` and your production domain) to OAuth Authorized JavaScript origins in Google Cloud.
+10. If your Postgres server does not support TLS (common on local development), append `?sslmode=disable` to `DATABASE_URL` / `POSTGRES_URL`.
 
 ---
 

--- a/ba_server/src/db/client.js
+++ b/ba_server/src/db/client.js
@@ -1,15 +1,17 @@
-const { neon } = require('@neondatabase/serverless');
+const { Pool } = require('pg');
 const {
   postgresUrl,
+  dbPoolMax,
   dbConnectionTimeoutMs,
+  dbIdleTimeoutMs,
   dbConnectRetries,
   dbConnectRetryDelayMs,
 } = require('../config/env');
 
-let queryClient = null;
+let pool = null;
 
 function ensureInitialized() {
-  if (!queryClient) {
+  if (!pool) {
     throw new Error('Database not initialized');
   }
 }
@@ -22,21 +24,52 @@ function replaceQuestionPlaceholders(sql) {
   });
 }
 
-function createQueryClient() {
-  const requestTimeoutMs =
+function createPool() {
+  const connectionTimeoutMs =
     Number.isFinite(dbConnectionTimeoutMs) && dbConnectionTimeoutMs > 0 ? dbConnectionTimeoutMs : 30000;
-  const supportsAbortTimeout =
-    typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function';
+  const idleTimeoutMs = Number.isFinite(dbIdleTimeoutMs) && dbIdleTimeoutMs > 0 ? dbIdleTimeoutMs : 30000;
+  const maxConnections = Number.isFinite(dbPoolMax) && dbPoolMax > 0 ? dbPoolMax : 5;
 
-  return neon(postgresUrl, {
-    fullResults: true,
-    fetchConnectionCache: true,
-    fetchOptions: supportsAbortTimeout
-      ? {
-          signal: AbortSignal.timeout(requestTimeoutMs),
-        }
-      : undefined,
+  return new Pool({
+    connectionString: postgresUrl,
+    max: maxConnections,
+    idleTimeoutMillis: idleTimeoutMs,
+    connectionTimeoutMillis: connectionTimeoutMs,
+    ssl: shouldUseSsl(postgresUrl) ? { rejectUnauthorized: false } : false,
   });
+}
+
+function shouldUseSsl(connectionString) {
+  if (!connectionString) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(connectionString);
+    const sslMode = String(parsed.searchParams.get('sslmode') || '').toLowerCase();
+    if (sslMode === 'disable') {
+      return false;
+    }
+
+    if (sslMode === 'require' || sslMode === 'prefer' || sslMode === 'allow' || sslMode === 'verify-ca' || sslMode === 'verify-full') {
+      return true;
+    }
+
+    const hostname = String(parsed.hostname || '').toLowerCase();
+    const isLocalHost =
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '::1' ||
+      hostname === '[::1]';
+
+    if (isLocalHost) {
+      return false;
+    }
+
+    return parsed.protocol === 'postgresql:' || parsed.protocol === 'postgres:';
+  } catch (_error) {
+    return true;
+  }
 }
 
 function sleep(ms) {
@@ -100,17 +133,9 @@ function isTransientConnectionError(error) {
 
 async function executeQuery(sql, params = []) {
   const queryText = replaceQuestionPlaceholders(sql);
-  const result = await queryClient.query(queryText, params);
-
-  if (Array.isArray(result)) {
-    return {
-      rows: result,
-      rowCount: result.length,
-    };
-  }
-
-  const rows = Array.isArray(result?.rows) ? result.rows : [];
-  const rowCount = Number.isFinite(Number(result?.rowCount)) ? Number(result.rowCount) : rows.length;
+  const result = await pool.query(queryText, params);
+  const rows = Array.isArray(result.rows) ? result.rows : [];
+  const rowCount = Number.isFinite(Number(result.rowCount)) ? Number(result.rowCount) : rows.length;
 
   return {
     rows,
@@ -119,7 +144,7 @@ async function executeQuery(sql, params = []) {
 }
 
 async function initializeClient() {
-  if (queryClient) {
+  if (pool) {
     return;
   }
 
@@ -134,14 +159,15 @@ async function initializeClient() {
   let lastError = null;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const candidateClient = createQueryClient();
+    const candidatePool = createPool();
 
     try {
-      await candidateClient.query('SELECT 1');
-      queryClient = candidateClient;
+      await candidatePool.query('SELECT 1');
+      pool = candidatePool;
       return;
     } catch (error) {
       lastError = error;
+      await candidatePool.end().catch(() => {});
 
       const canRetry = isTransientConnectionError(error) && attempt < maxAttempts;
       if (!canRetry) {


### PR DESCRIPTION
### Motivation
- The previous `@neondatabase/serverless` client caused connection failures for standard or self-hosted Postgres instances and lacked pooling behavior for typical Node deployments. 
- Improve reliability for both production and local development by using the standard `pg` driver and clearer SSL handling.

### Description
- Replaced the Neon client with `pg`'s `Pool` in `ba_server/src/db/client.js` and wired pool settings from env vars (`DB_POOL_MAX`, `DB_IDLE_TIMEOUT_MS`, `DB_CONNECTION_TIMEOUT_MS`).
- Added `shouldUseSsl` logic that respects `sslmode` query param and disables SSL for loopback/localhost hosts, and sets `ssl` on the `Pool` accordingly.
- Preserved existing query placeholder conversion and public API (`initializeClient`, `run`, `get`, `all`), kept startup retry/backoff behavior, and added cleanup of failed candidate pools via `candidatePool.end()`.
- Documented local TLS troubleshooting in `README.md` by recommending `?sslmode=disable` for non‑TLS Postgres during development.

### Testing
- Loaded the updated DB client module successfully with `node -e "require('./ba_server/src/db/client')"` (no errors on require).
- No automated unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfcb305eec8325898aeae748a56976)