### PR TITLE
Refine multiplayer wording to “Local” and overhaul mode-selection UI & previews

### DIFF
--- a/ba_web/src/app/globals.css
+++ b/ba_web/src/app/globals.css
@@ -186,45 +186,37 @@ h1 span:last-child {
 }
 
 .lobby-play-mode-slider {
-  position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.2rem;
+  gap: 0.35rem;
   border: 2px solid var(--lobby-border);
-  border-radius: 999px;
-  padding: 0.2rem;
+  border-radius: 14px;
+  padding: 0.35rem;
   background:
     linear-gradient(145deg, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.2)),
     radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 62%);
+  overflow: hidden;
 }
 
 .lobby-play-mode-slider-thumb {
-  position: absolute;
-  top: 0.2rem;
-  left: 0.2rem;
-  bottom: 0.2rem;
-  border-radius: 999px;
-  background:
-    radial-gradient(circle at top left, rgba(255, 255, 255, 0.22), transparent 62%),
-    linear-gradient(126deg, rgba(11, 46, 84, 0.92), rgba(10, 92, 65, 0.9));
-  border: 2px solid rgba(0, 0, 0, 0.76);
-  transition: transform 170ms ease, width 170ms ease;
-  pointer-events: none;
+  display: none;
 }
 
 .lobby-play-mode-btn {
-  position: relative;
-  z-index: 1;
-  border: 2px solid transparent;
-  border-radius: 999px;
-  min-height: 40px;
-  background: transparent;
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  border-radius: 12px;
+  min-height: 84px;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.2);
   color: rgba(0, 0, 0, 0.68);
-  display: inline-flex;
-  align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   justify-content: center;
-  font-size: 1.1rem;
-  transition: color 160ms ease, transform 160ms ease, opacity 160ms ease;
+  gap: 0.15rem;
+  font-size: 1rem;
+  text-align: left;
+  transition: color 160ms ease, transform 160ms ease, opacity 160ms ease, border-color 160ms ease, background 160ms ease;
 }
 
 .lobby-play-mode-btn:hover:not(:disabled) {
@@ -238,6 +230,28 @@ h1 span:last-child {
 
 .lobby-play-mode-btn-active {
   color: #fff;
+  border-color: rgba(0, 0, 0, 0.85);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.24), transparent 62%),
+    linear-gradient(126deg, rgba(11, 46, 84, 0.92), rgba(10, 92, 65, 0.9));
+}
+
+.lobby-play-mode-btn-icon {
+  font-size: 1.25rem;
+}
+
+.lobby-play-mode-btn-label {
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.lobby-play-mode-btn-copy {
+  margin: 0;
+  font-size: 0.66rem;
+  line-height: 1.2;
+  opacity: 0.88;
 }
 
 .lobby-play-mode-meta {
@@ -309,12 +323,14 @@ h1 span:last-child {
 }
 
 .lobby-cpu-cta {
-  display: inline-flex;
+  display: flex;
+  width: 100%;
+  min-height: 92px;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
-  gap: 0.2rem;
-  padding: 0.56rem 0.9rem;
+  gap: 0.35rem;
+  padding: 0.86rem 0.95rem;
   background:
     radial-gradient(circle at top left, rgba(255, 255, 255, 0.24), transparent 60%),
     linear-gradient(125deg, rgba(17, 17, 17, 0.85), rgba(10, 56, 44, 0.9));
@@ -327,21 +343,21 @@ h1 span:last-child {
 }
 
 .lobby-cpu-cta small {
-  font-size: 0.68rem;
+  font-size: 0.76rem;
   opacity: 0.86;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .lobby-online-cta-tip {
-  min-height: 54px;
+  min-height: 92px;
   border: 2px dashed var(--lobby-border-strong);
   border-radius: 12px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.32rem;
-  padding: 0.45rem 0.6rem;
+  padding: 0.85rem 0.95rem;
   background: rgba(255, 255, 255, 0.28);
   color: #111;
   font-size: 0.8rem;
@@ -2238,6 +2254,16 @@ h1 span:last-child {
   transition: none !important;
 }
 
+.motion-off .board-stage-card,
+.motion-off .board,
+.motion-off .solo-2048-board,
+.motion-off .solo-sudoku-board,
+.motion-off .solo-mines-board,
+.motion-off .solo-memory-board,
+.motion-off .solo-dino-stage-wrap {
+  transform: none !important;
+}
+
 .app-loader-overlay {
   position: fixed;
   inset: 0;
@@ -2410,10 +2436,18 @@ h1 span:last-child {
 }
 
 .room-float-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   font-size: 1rem;
   line-height: 1.15;
   letter-spacing: 0.02em;
   text-align: right;
+}
+
+.room-float-title-icon {
+  font-size: 0.9rem;
+  opacity: 0.85;
 }
 
 .room-float-toggle-btn {
@@ -2437,7 +2471,7 @@ h1 span:last-child {
   border: none;
   background: transparent;
   color: inherit;
-  font-size: 2.2rem;
+  font-size: 1.45rem;
 }
 
 .room-score-strip {
@@ -3616,9 +3650,7 @@ h1 span:last-child {
 }
 
 .game-type-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.95fr);
-  gap: 0.9rem;
+  display: block;
 }
 
 .game-type-grid {
@@ -3702,11 +3734,13 @@ h1 span:last-child {
 
 .game-type-play-btn {
   width: 100%;
-  border: none;
-  border-top: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0 0 14px 14px;
-  padding: 0.8rem 1rem;
-  background: rgba(255, 255, 255, 0.12);
+  border: 2px solid rgba(0, 0, 0, 0.85);
+  border-radius: 999px;
+  min-height: 46px;
+  padding: 0.65rem 1rem;
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.24), transparent 62%),
+    linear-gradient(126deg, rgba(11, 46, 84, 0.92), rgba(10, 92, 65, 0.9));
   color: #fff;
   font-weight: 700;
   cursor: pointer;
@@ -3728,6 +3762,26 @@ h1 span:last-child {
   display: flex;
   flex-direction: column;
   gap: 0.72rem;
+}
+.game-type-card-preview {
+  border-top: 1px solid rgba(255, 255, 255, 0.18);
+  padding: 0.65rem 0.82rem 0.82rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.52rem;
+}
+
+.game-type-card-preview-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.game-type-card-preview-head p {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.3;
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .game-type-preview-head {
@@ -4805,14 +4859,6 @@ h1 span:last-child {
 }
 
 @media (max-width: 960px) {
-  .game-type-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .game-type-preview {
-    order: -1;
-  }
-
   .choose-game-toolbar {
     flex-wrap: wrap;
   }

--- a/ba_web/src/app/page.tsx
+++ b/ba_web/src/app/page.tsx
@@ -228,7 +228,7 @@ const APP_MUSIC_TRACKS: MusicTrack[] = [
 ];
 
 const GOOGLE_ONLINE_NOTICE_MESSAGE =
-  'Sign in with Google to access online multiplayer. CPU and offline play do not need an account.';
+  'Sign in with Google to access online multiplayer. CPU and local play do not need an account.';
 
 export default function Home() {
   const [screen, setScreen] = useState<Screen>('home');
@@ -1022,7 +1022,7 @@ export default function Home() {
       beginMatch('offline', null, selectedGame);
       setMessage('');
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not start offline match');
+      setMessage(error instanceof Error ? error.message : 'Could not start local match');
     } finally {
       setIsLoading(false);
     }

--- a/ba_web/src/features/game/CpuArenaGame.tsx
+++ b/ba_web/src/features/game/CpuArenaGame.tsx
@@ -9,7 +9,7 @@ import {
   AiOutlinePlayCircle,
   AiOutlineCheckCircle,
   AiOutlineArrowDown,
-  AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineUser,
   AiOutlineCrown,
   AiOutlineDrag,
@@ -207,7 +207,7 @@ export function CpuArenaGame({
           <div className={`room-float-card${isRoomCardCollapsed ? ' room-float-card-collapsed' : ''}`}>
             {isRoomCardCollapsed ? (
               <button className="room-float-collapsed-center" type="button" onClick={() => setIsRoomCardCollapsed(false)} aria-label="Expand room info" title="Expand room info">
-                <AiOutlineArrowUp />
+                <AiOutlineInfoCircle />
               </button>
             ) : (
               <>
@@ -215,7 +215,7 @@ export function CpuArenaGame({
                   <span className="room-float-anchor">
                     <AiOutlineDrag /> drag
                   </span>
-                  <span className="room-float-title">{gameLabel} CPU Match ({difficulty})</span>
+                  <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} CPU Match ({difficulty})</span>
                   <button className="room-float-toggle-btn" type="button" onClick={() => setIsRoomCardCollapsed(true)} aria-label="Collapse room info" title="Collapse room info">
                     <AiOutlineArrowDown />
                   </button>

--- a/ba_web/src/features/game/OfflineArenaGame.tsx
+++ b/ba_web/src/features/game/OfflineArenaGame.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import {
   AiOutlineArrowDown,
-  AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineCheckCircle,
   AiOutlineClockCircle,
   AiOutlineCrown,
@@ -130,18 +130,18 @@ export function OfflineArenaGame({
 
   const status = useMemo(() => {
     if (winner === 'draw') {
-      return `${gameLabel} | Offline Match | Draw`;
+      return `${gameLabel} | Local Match | Draw`;
     }
     if (winner === 'X') {
-      return `${gameLabel} | Offline Match | ${playerLabels.x} win`;
+      return `${gameLabel} | Local Match | ${playerLabels.x} win`;
     }
     if (winner === 'O') {
-      return `${gameLabel} | Offline Match | ${playerLabels.o} win`;
+      return `${gameLabel} | Local Match | ${playerLabels.o} win`;
     }
     if (!activeTurnParticipant) {
-      return `${gameLabel} | Offline Match | ${playerLabels[turn.toLowerCase() as 'x' | 'o']} to move`;
+      return `${gameLabel} | Local Match | ${playerLabels[turn.toLowerCase() as 'x' | 'o']} to move`;
     }
-    return `${gameLabel} | Offline Match | ${formatParticipantLabel(activeTurnParticipant)} turn`;
+    return `${gameLabel} | Local Match | ${formatParticipantLabel(activeTurnParticipant)} turn`;
   }, [activeTurnParticipant, gameLabel, playerLabels, turn, winner]);
 
   const roomStatusIcon = winner
@@ -219,7 +219,7 @@ export function OfflineArenaGame({
       mode: 'offline',
       gameType,
       outcome: winner === 'draw' ? 'draw' : winner === primarySymbol ? 'win' : 'loss',
-      opponent: opponent || 'Offline Opponent',
+      opponent: opponent || 'Local Opponent',
     });
   }, [gameType, onMatchComplete, participants, winner]);
 
@@ -231,7 +231,7 @@ export function OfflineArenaGame({
 
       {showAdaptiveController ? (
         <AdaptiveControllerOverlay
-          title="Offline Match"
+          title="Local Match"
           subtitle="Local turn-based controls"
           buttons={controllerButtons}
         />
@@ -248,7 +248,7 @@ export function OfflineArenaGame({
                 aria-label="Expand room info"
                 title="Expand room info"
               >
-                <AiOutlineArrowUp />
+                <AiOutlineInfoCircle />
               </button>
             ) : (
               <>
@@ -256,7 +256,7 @@ export function OfflineArenaGame({
                   <span className="room-float-anchor">
                     <AiOutlineDrag /> drag
                   </span>
-                  <span className="room-float-title">{gameLabel} Offline Match</span>
+                  <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Local Match</span>
                   <button
                     className="room-float-toggle-btn"
                     type="button"
@@ -326,7 +326,7 @@ export function OfflineArenaGame({
       <PlayerX
         pieceLabel={playerLabels.x}
         alias={xParticipants.map((entry) => `${entry.token}:${entry.name}`).join(' | ') || 'Team X'}
-        picture={`https://robohash.org/offline-x-${gameType}`}
+        picture={`https://robohash.org/local-x-${gameType}`}
         wins={player.wins}
         losses={player.losses}
         draws={player.draws}
@@ -350,7 +350,7 @@ export function OfflineArenaGame({
       <PlayerO
         pieceLabel={playerLabels.o}
         alias={oParticipants.map((entry) => `${entry.token}:${entry.name}`).join(' | ') || 'Team O'}
-        picture={`https://robohash.org/offline-o-${gameType}`}
+        picture={`https://robohash.org/local-o-${gameType}`}
         wins={0}
         losses={0}
         draws={0}

--- a/ba_web/src/features/game/OnlineArenaGame.tsx
+++ b/ba_web/src/features/game/OnlineArenaGame.tsx
@@ -9,7 +9,7 @@ import {
   AiOutlinePlayCircle,
   AiOutlineCheckCircle,
   AiOutlineArrowDown,
-  AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineUser,
   AiOutlineCrown,
   AiOutlineDrag,
@@ -347,7 +347,7 @@ export function OnlineArenaGame({
                 aria-label="Expand room info"
                 title="Expand room info"
               >
-                <AiOutlineArrowUp />
+                <AiOutlineInfoCircle />
               </button>
             ) : (
               <>
@@ -355,7 +355,7 @@ export function OnlineArenaGame({
                   <span className="room-float-anchor">
                     <AiOutlineDrag /> drag
                   </span>
-                  <span className="room-float-title">
+                  <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> 
                     {room ? `${room.name} (${room.code}) | ${gameLabel}` : 'Loading room'}
                   </span>
                   <button

--- a/ba_web/src/features/game/Solo2048Game.tsx
+++ b/ba_web/src/features/game/Solo2048Game.tsx
@@ -9,6 +9,7 @@ import {
   AiOutlineArrowLeft,
   AiOutlineArrowRight,
   AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineReload,
   AiOutlineSound,
 } from 'react-icons/ai';
@@ -354,7 +355,7 @@ export function Solo2048Game({
               aria-label="Expand game info"
               title="Expand game info"
             >
-              <AiOutlineArrowUp />
+              <AiOutlineInfoCircle />
             </button>
           ) : (
             <>
@@ -362,7 +363,7 @@ export function Solo2048Game({
                 <span className="room-float-anchor">
                   <AiOutlineDrag /> drag
                 </span>
-                <span className="room-float-title">{gameLabel} Solo</span>
+                <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Solo</span>
                 <button
                   className="room-float-toggle-btn"
                   type="button"

--- a/ba_web/src/features/game/SoloDinoGame.tsx
+++ b/ba_web/src/features/game/SoloDinoGame.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion';
 import {
   AiOutlineArrowDown,
   AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineDrag,
   AiOutlineReload,
   AiOutlineSound,
@@ -668,7 +669,7 @@ export function SoloDinoGame({
               aria-label="Expand game info"
               title="Expand game info"
             >
-              <AiOutlineArrowUp />
+              <AiOutlineInfoCircle />
             </button>
           ) : (
             <>
@@ -676,7 +677,7 @@ export function SoloDinoGame({
                 <span className="room-float-anchor">
                   <AiOutlineDrag /> drag
                 </span>
-                <span className="room-float-title">{gameLabel} Solo</span>
+                <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Solo</span>
                 <button
                   className="room-float-toggle-btn"
                   type="button"

--- a/ba_web/src/features/game/SoloMemoryMatchGame.tsx
+++ b/ba_web/src/features/game/SoloMemoryMatchGame.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { motion } from 'framer-motion';
 import {
   AiOutlineArrowDown,
-  AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineDrag,
   AiOutlineFlag,
   AiOutlineReload,
@@ -321,7 +321,7 @@ export function SoloMemoryMatchGame({
               aria-label="Expand game info"
               title="Expand game info"
             >
-              <AiOutlineArrowUp />
+              <AiOutlineInfoCircle />
             </button>
           ) : (
             <>
@@ -329,7 +329,7 @@ export function SoloMemoryMatchGame({
                 <span className="room-float-anchor">
                   <AiOutlineDrag /> drag
                 </span>
-                <span className="room-float-title">{gameLabel} Solo</span>
+                <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Solo</span>
                 <button
                   className="room-float-toggle-btn"
                   type="button"

--- a/ba_web/src/features/game/SoloMinesweeperGame.tsx
+++ b/ba_web/src/features/game/SoloMinesweeperGame.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { motion } from 'framer-motion';
 import {
   AiOutlineArrowDown,
-  AiOutlineArrowUp,
   AiOutlineDrag,
   AiOutlineFlag,
   AiOutlineInfoCircle,
@@ -371,7 +370,7 @@ export function SoloMinesweeperGame({
               aria-label="Expand game info"
               title="Expand game info"
             >
-              <AiOutlineArrowUp />
+              <AiOutlineInfoCircle />
             </button>
           ) : (
             <>
@@ -379,7 +378,7 @@ export function SoloMinesweeperGame({
                 <span className="room-float-anchor">
                   <AiOutlineDrag /> drag
                 </span>
-                <span className="room-float-title">{gameLabel} Solo</span>
+                <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Solo</span>
                 <button
                   className="room-float-toggle-btn"
                   type="button"

--- a/ba_web/src/features/game/SoloSudokuGame.tsx
+++ b/ba_web/src/features/game/SoloSudokuGame.tsx
@@ -9,6 +9,7 @@ import {
   AiOutlineArrowLeft,
   AiOutlineArrowRight,
   AiOutlineArrowUp,
+  AiOutlineInfoCircle,
   AiOutlineDrag,
   AiOutlineFlag,
   AiOutlineReload,
@@ -452,7 +453,7 @@ export function SoloSudokuGame({
               aria-label="Expand game info"
               title="Expand game info"
             >
-              <AiOutlineArrowUp />
+              <AiOutlineInfoCircle />
             </button>
           ) : (
             <>
@@ -460,7 +461,7 @@ export function SoloSudokuGame({
                 <span className="room-float-anchor">
                   <AiOutlineDrag /> drag
                 </span>
-                <span className="room-float-title">{gameLabel} Solo</span>
+                <span className="room-float-title"><AiOutlineInfoCircle className="room-float-title-icon" /> {gameLabel} Solo</span>
                 <button
                   className="room-float-toggle-btn"
                   type="button"

--- a/ba_web/src/features/home/GameTypeSelectScreen.tsx
+++ b/ba_web/src/features/home/GameTypeSelectScreen.tsx
@@ -6,7 +6,6 @@ import {
   AiOutlineArrowLeft,
   AiOutlineAppstore,
   AiOutlineCheckCircle,
-  AiOutlineCompass,
   AiOutlineRobot,
   AiOutlineTeam,
   AiOutlineThunderbolt,
@@ -77,17 +76,38 @@ export function GameTypeSelectScreen({
       icon: <AiOutlineRobot />,
     },
   ];
-  const selectedOption =
-    gameTypeOptions.find((option) => option.id === selectedCategory) || gameTypeOptions[0];
-  const selectedGames = games.filter((game) => {
-    if (selectedCategory === 'online-multiplayer') {
-      return game.supportsOnline && game.minPlayers >= 2;
+  const getGamesForCategory = useCallback(
+    (category: GameTypeCategory) =>
+      games.filter((game) => {
+        if (category === 'online-multiplayer') {
+          return game.supportsOnline && game.minPlayers >= 2;
+        }
+        if (category === 'single-player') {
+          return !game.supportsOnline || game.maxPlayers === 1;
+        }
+        return true;
+      }),
+    [games]
+  );
+  const getCategoryActionLabel = useCallback((category: GameTypeCategory) => {
+    if (category === 'single-player') {
+      return 'Start Solo Run';
     }
-    if (selectedCategory === 'single-player') {
-      return !game.supportsOnline || game.maxPlayers === 1;
+    if (category === 'online-multiplayer') {
+      return 'Start Multiplayer Queue';
     }
-    return true;
-  });
+    return 'Continue';
+  }, []);
+
+  const getCategoryActionHint = useCallback((category: GameTypeCategory) => {
+    if (category === 'single-player') {
+      return 'Jump into solo challenges and practice sessions.';
+    }
+    if (category === 'online-multiplayer') {
+      return 'Create or join a room from the next screen.';
+    }
+    return 'Browse and pick any available game.';
+  }, []);
 
   return (
     <section className="title-screen-content">
@@ -106,19 +126,21 @@ export function GameTypeSelectScreen({
 
         <div className="game-type-banner">
           <strong>Choose Your Arena Focus</strong>
-          <span>Pick a mode lane first, then lock in the exact game on the next screen.</span>
+          <span>Pick the lane you want, then continue with that mode.</span>
         </div>
 
-        <div className="game-type-layout">
-          <div className="game-type-grid">
-            {gameTypeOptions.map((option) => (
+        <div className="game-type-grid">
+          {gameTypeOptions.map((option) => {
+            const optionGames = getGamesForCategory(option.id);
+            const isSelected = selectedCategory === option.id;
+            return (
               <div
                 key={option.id}
                 className={classnames(
                   'game-type-card',
                   'flex',
                   'flex-col',
-                  selectedCategory === option.id && 'game-type-card-active'
+                  isSelected && 'game-type-card-active'
                 )}
               >
                 <button
@@ -134,47 +156,33 @@ export function GameTypeSelectScreen({
                   <span>{option.detail}</span>
                 </button>
 
-                {selectedCategory === option.id ? (
-                  <button className="game-type-play-btn" type="button" onClick={onContinue}>
-                    <AiOutlineCheckCircle /> Continue
-                  </button>
+                {isSelected ? (
+                  <div className="game-type-card-preview">
+                    <div className="game-type-card-preview-head">
+                      <span className="game-type-preview-pill">
+                        <AiOutlineThunderbolt /> {optionGames.length} Available
+                      </span>
+                      <p>{getCategoryActionHint(option.id)}</p>
+                    </div>
+                    <ul className="game-type-preview-list">
+                      {optionGames.slice(0, 3).map((game) => (
+                        <li key={game.id}>
+                          <span>{game.name}</span>
+                          <small>
+                            {game.minPlayers}-{game.maxPlayers} players
+                          </small>
+                        </li>
+                      ))}
+                      {optionGames.length > 3 ? <li>+ {optionGames.length - 3} more</li> : null}
+                    </ul>
+                    <button className="game-type-play-btn" type="button" onClick={onContinue}>
+                      <AiOutlineCheckCircle /> {getCategoryActionLabel(option.id)}
+                    </button>
+                  </div>
                 ) : null}
               </div>
-            ))}
-          </div>
-
-          <aside className="game-type-preview">
-            <div className="game-type-preview-head">
-              <p className="game-type-preview-label">Selected Lane</p>
-              <strong>{selectedOption.label}</strong>
-              <span>{selectedOption.detail}</span>
-            </div>
-
-            <div className="game-type-preview-stats">
-              <span className="game-type-preview-pill">
-                <AiOutlineCompass /> {selectedGames.length} Available
-              </span>
-              <span className="game-type-preview-pill">
-                <AiOutlineThunderbolt /> Ready to Queue
-              </span>
-            </div>
-
-            <ul className="game-type-preview-list">
-              {selectedGames.slice(0, 5).map((game) => (
-                <li key={game.id}>
-                  <span>{game.name}</span>
-                  <small>
-                    {game.minPlayers}-{game.maxPlayers} players
-                  </small>
-                </li>
-              ))}
-              {selectedGames.length > 5 ? <li>+ {selectedGames.length - 5} more</li> : null}
-            </ul>
-
-            <button className="game-type-preview-cta" type="button" onClick={onContinue}>
-              <AiOutlineCheckCircle /> Continue With {selectedOption.label}
-            </button>
-          </aside>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/ba_web/src/features/home/HistoryScreen.tsx
+++ b/ba_web/src/features/home/HistoryScreen.tsx
@@ -89,7 +89,7 @@ export function HistoryScreen({ history, selectedGame, games, onBack, onClear, o
               <li key={entry.id} className="settings-history-item">
                 <span className={classnames('settings-history-outcome', `outcome-${entry.outcome}`)}>{entry.outcome.toUpperCase()}</span>
                 <span className="settings-history-opponent">
-                  {formatGameName(entry.gameType, games)} | {entry.mode.toUpperCase()} vs {entry.opponent}
+                  {formatGameName(entry.gameType, games)} | {(entry.mode === 'offline' ? 'LOCAL' : entry.mode.toUpperCase())} vs {entry.opponent}
                 </span>
                 <span className="settings-history-time">{new Date(entry.finishedAt).toLocaleString()}</span>
               </li>

--- a/ba_web/src/features/home/LobbyScreen.tsx
+++ b/ba_web/src/features/home/LobbyScreen.tsx
@@ -126,7 +126,7 @@ export function LobbyScreen({
       {
         id: 'offline' as const,
         icon: <AiOutlineTeam />,
-        label: 'Offline Multiplayer',
+        label: 'Local Multiplayer',
         description: supportsOffline
           ? 'Play locally with shared turns on one device.'
           : `${selectedGameName} is single-player only.`,
@@ -135,10 +135,6 @@ export function LobbyScreen({
     ],
     [isSinglePlayerMode, selectedGameName, supportsCpu, supportsOffline, supportsOnline]
   );
-  const selectedModeIndex = Math.max(0, modeOptions.findIndex((option) => option.id === playMode));
-  const activeModeOption = modeOptions.find((option) => option.id === playMode) || modeOptions[0];
-  const activeModeThumbWidth = `${100 / Math.max(1, modeOptions.length)}%`;
-  const activeModeThumbTransform = `translateX(${selectedModeIndex * 100}%)`;
   const offlineSeats = useMemo(
     () => getOfflineSeats(selectedGame, offlinePlayerCount),
     [offlinePlayerCount, selectedGame]
@@ -279,13 +275,6 @@ export function LobbyScreen({
               <div className="lobby-play-mode-stack">
                 <span className="lobby-select-caption">Play Mode</span>
                 <div className="lobby-play-mode-slider" role="tablist" aria-label="Play mode selector">
-                  <span
-                    className="lobby-play-mode-slider-thumb"
-                    style={{
-                      width: activeModeThumbWidth,
-                      transform: activeModeThumbTransform,
-                    }}
-                  />
                   {modeOptions.map((modeOption) => (
                     <button
                       key={modeOption.id}
@@ -301,13 +290,11 @@ export function LobbyScreen({
                       disabled={modeOption.disabled}
                       onClick={() => onPlayModeChange(modeOption.id)}
                     >
-                      {modeOption.icon}
+                      <span className="lobby-play-mode-btn-icon">{modeOption.icon}</span>
+                      <span className="lobby-play-mode-btn-label">{modeOption.label}</span>
+                      <small className="lobby-play-mode-btn-copy">{modeOption.description}</small>
                     </button>
                   ))}
-                </div>
-                <div className="lobby-play-mode-meta">
-                  <strong>{activeModeOption.label}</strong>
-                  <span>{activeModeOption.description}</span>
                 </div>
               </div>
 
@@ -345,7 +332,13 @@ export function LobbyScreen({
                 <span className="lobby-cpu-cta-main">
                   <AiOutlineRobot /> Play {selectedGameName} vs CPU
                 </span>
-                <small>{supportsCpu ? 'Quick practice run' : ''}</small>
+                <small>
+                  {supportsCpu
+                    ? isSinglePlayerMode
+                      ? 'Solo challenge run'
+                      : 'Head-to-head training match'
+                    : ''}
+                </small>
               </button>
             ) : playMode === 'offline' ? (
               <button
@@ -355,14 +348,17 @@ export function LobbyScreen({
                 onClick={onPlayOffline}
               >
                 <span className="lobby-cpu-cta-main">
-                  <AiOutlineTeam /> Start Offline Match
+                  <AiOutlineTeam /> Start Local Match
                 </span>
                 <small>{supportsOffline ? 'Local shared-device turn play' : ''}</small>
               </button>
             ) : (
-              <div className="lobby-online-cta-tip">
-                <AiOutlineGlobal /> Create or join an online room below.
-              </div>
+              <button className={classnames('lobby-btn', 'custome-shadow', 'lobby-cpu-cta')} type="button" disabled>
+                <span className="lobby-cpu-cta-main">
+                  <AiOutlineGlobal /> Online Room Matchmaking
+                </span>
+                <small>Create or join the room below.</small>
+              </button>
             )}
           </div>
         </div>
@@ -381,7 +377,7 @@ export function LobbyScreen({
                 CPU {supportsCpu ? 'On' : 'Off'}
               </span>
               <span className={classnames('lobby-flag', supportsOffline ? 'lobby-flag-on' : 'lobby-flag-off')}>
-                Offline {supportsOffline ? 'On' : 'Off'}
+                Local {supportsOffline ? 'On' : 'Off'}
               </span>
             </div>
           </div>
@@ -530,7 +526,7 @@ export function LobbyScreen({
             <section className="lobby-panel lobby-panel-create">
               <div className="lobby-panel-head lobby-panel-head-static">
                 <div>
-                  <p className="lobby-panel-title">Offline Setup</p>
+                  <p className="lobby-panel-title">Local Setup</p>
                   <p className="lobby-panel-subtitle">
                     Configure local players. Turns rotate per team on one device.
                   </p>


### PR DESCRIPTION
### Motivation
- Make user-facing terminology clearer by replacing "offline" with "local" where it refers to shared-device multiplayer, and align related labels/messages across the app. 
- Simplify the game-type selection flow by showing the selected option's preview inline and reduce visual clutter from separate preview panels. 
- Improve the lobby mode selector and CTA area so CPU/Local/Online modes have consistent, larger action affordances and clearer copy distinguishing solo vs CPU play. 
- Make floating info cards and the adaptive-controller visual language more consistent and ensure boards lose skew/tilt when motion is disabled.

### Description
- Replaced displayed wording and labels from `Offline` to `Local` in lobby, history, match titles, help text, and local-match CTAs while keeping internal mode IDs unchanged (notably in `LobbyScreen.tsx`, `OfflineArenaGame.tsx`, `HistoryScreen.tsx`, `page.tsx`).
- Reworked the lobby play-mode selector into three descriptive cards with icon + label + description and larger adaptive CTA sizing for CPU/Local/Online modes; updated CTA copy to differentiate solo CPU runs and to place the online message in the same CTA footprint (`ba_web/src/features/home/LobbyScreen.tsx`, `ba_web/src/app/globals.css`).
- Replaced the separate side preview on the Game Type screen with embedded preview content inside the selected card, showing a short list, stats and a single action button (`ba_web/src/features/home/GameTypeSelectScreen.tsx`, corresponding CSS changes in `globals.css`).
- Updated floating info card behavior and styling to match the adaptive-controller style: collapsed trigger now uses an info icon, title rows include a small info icon, and collapsed icon sizing reduced (`OnlineArenaGame.tsx`, `CpuArenaGame.tsx`, `OfflineArenaGame.tsx`, several `Solo*Game.tsx` files, and `globals.css`).
- Adjusted CSS to fix play-mode overflow, increase mode-card spacing, change button sizing, and add `motion-off` transform overrides so boards/stages stop being skewed when animations are disabled (`ba_web/src/app/globals.css`).
- Minor copy and robohash image id changes for local images (e.g. `offline-x-` → `local-x-`) and history display mapping of `offline` → `LOCAL` for readability.

### Testing
- No automated tests were run as per repository AGENTS.md guidance; changes were limited to UI text, layout, and icons and were committed after local edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cecf860883258c8673454a7bb126)