### PR TITLE
Overhaul chat/friends flow and add unified dock hub

### DIFF
--- a/ba_server/src/repositories/chatRepository.js
+++ b/ba_server/src/repositories/chatRepository.js
@@ -29,11 +29,11 @@ async function searchPlayers(query) {
      FROM players p
      LEFT JOIN google_accounts ga ON ga.player_id = p.id
      LEFT JOIN player_game_stats s ON s.player_id = p.id
-     WHERE p.name ILIKE ?
+     WHERE p.name ILIKE ? OR p.id ILIKE ?
      GROUP BY p.id, p.name, ga.picture
      ORDER BY p.name ASC
      LIMIT 20`,
-    [like]
+    [like, like]
   );
 }
 
@@ -67,7 +67,8 @@ async function listInvitesForPlayer(playerId) {
 async function createFriendRequest({ fromPlayerId, toPlayerId, message }) {
   await run(
     `INSERT INTO friend_requests (from_player_id, to_player_id, message, status, created_at)
-     VALUES (?, ?, ?, 'pending', CURRENT_TIMESTAMP)`,
+     VALUES (?, ?, ?, 'pending', CURRENT_TIMESTAMP)
+     ON CONFLICT DO NOTHING`,
     [fromPlayerId, toPlayerId, message || null]
   );
 }

--- a/ba_server/src/routes/chatRoutes.js
+++ b/ba_server/src/routes/chatRoutes.js
@@ -131,4 +131,44 @@ router.post(
   })
 );
 
+
+
+router.get(
+  '/friend-requests',
+  asyncHandler(async (req, res) => {
+    const playerId = req.auth.playerId;
+    const requests = await listFriendRequestsFor(playerId);
+    const normalized = requests.map((request) => ({
+      id: String(request.id),
+      fromPlayerId: request.from_player_id,
+      fromPlayerName: request.from_name,
+      fromPicture: request.from_picture,
+      message: request.message,
+      status: request.status,
+      createdAt: request.created_at,
+    }));
+    res.json({ requests: normalized });
+  })
+);
+
+router.post(
+  '/friend-requests/:id/accept',
+  asyncHandler(async (req, res) => {
+    const accepted = await acceptFriendRequest(req.params.id);
+    if (!accepted) {
+      return res.status(404).json({ error: 'Friend request not found' });
+    }
+    notifications.notifyPlayer(accepted.from_player_id, { type: 'friend-accepted', by: accepted.to_player_id });
+    res.json({ ok: true });
+  })
+);
+
+router.post(
+  '/friend-requests/:id/reject',
+  asyncHandler(async (req, res) => {
+    await updateFriendRequestStatus(req.params.id, 'rejected');
+    res.json({ ok: true });
+  })
+);
+
 module.exports = router;

--- a/ba_web/src/app/globals.css
+++ b/ba_web/src/app/globals.css
@@ -6765,3 +6765,5 @@ h1 span:last-child {
 .chat-popup-w svg, .chat-popup-d svg, .chat-popup-l svg {
   margin-right: 0.1rem;
 }
+
+.dock-hub{position:fixed;right:1rem;bottom:1rem;z-index:95;display:flex;flex-direction:column;gap:.35rem;align-items:flex-end}.dock-hub-actions{display:flex;gap:.35rem}.dock-hub .music-dock-toggle{width:2.5rem;height:2.5rem}.chat-dock .profile-dock-panel{border-color:rgba(15,15,15,.85);background:linear-gradient(145deg,rgba(9,38,66,.9),rgba(13,78,61,.82));box-shadow:0 14px 36px rgba(0,0,0,.45)}

--- a/ba_web/src/app/page.tsx
+++ b/ba_web/src/app/page.tsx
@@ -273,6 +273,7 @@ export default function Home() {
   const [friendsList, setFriendsList] = useState<Array<{ playerId: string; name: string; picture?: string | null }>>([]);
   const [pendingInvites, setPendingInvites] = useState<any[]>([]);
   const [isNoticeDockOpen, setIsNoticeDockOpen] = useState(false);
+  const [isDockHubOpen, setIsDockHubOpen] = useState(true);
   const [isGoogleSignInLoading, setIsGoogleSignInLoading] = useState(false);
   const [pageReady, setPageReady] = useState(false);
   const isGoogleSignInInFlightRef = useRef(false);
@@ -923,13 +924,27 @@ export default function Home() {
 
   const refreshPendingInvites = async () => {
     try {
-      const payload = await callApi<{ invites: Array<{ id: string; fromPlayerId: string; fromPlayerName: string; message?: string }> }>('/api/chat/invites', {
+      const payload = await callApi<{ requests: Array<{ id: string; fromPlayerId: string; fromPlayerName: string; message?: string }> }>('/api/chat/friend-requests', {
         method: 'GET',
       });
-      setPendingInvites(Array.isArray(payload?.invites) ? payload.invites : []);
+      setPendingInvites(Array.isArray(payload?.requests) ? payload.requests : []);
     } catch (error) {
       console.error('Refresh pending invites error:', error);
     }
+  };
+
+
+
+  const acceptFriendRequest = async (requestId: string) => {
+    await callApi(`/api/chat/friend-requests/${requestId}/accept`, { method: 'POST' });
+    await Promise.all([refreshPendingInvites(), refreshFriends()]);
+    setMessage('Friend request accepted.');
+  };
+
+  const rejectFriendRequest = async (requestId: string) => {
+    await callApi(`/api/chat/friend-requests/${requestId}/reject`, { method: 'POST' });
+    await refreshPendingInvites();
+    setMessage('Friend request rejected.');
   };
 
   const inviteFriendsToRoom = async (roomCode: string) => {
@@ -1807,6 +1822,7 @@ export default function Home() {
           playerProfile={player}
           playerName={playerName}
           isSigningIn={isGoogleSignInLoading}
+          showLauncher={false}
           onToggleOpen={() => setIsProfileDockOpen((currentValue) => !currentValue)}
           onSignIn={startGoogleSignIn}
           onSignOut={signOutGoogle}
@@ -1839,7 +1855,7 @@ export default function Home() {
           tracks={APP_MUSIC_TRACKS}
           isMuted={isMusicMuted}
           volume={musicVolume}
-          showLauncher={!isProfileDockOpen}
+showLauncher={false}
           onToggleMute={() => {
             const nextValue = !isMusicMuted;
             setIsMusicMuted(nextValue);
@@ -1854,13 +1870,26 @@ export default function Home() {
           isOpen={isChatDockOpen}
           friends={friendsList}
           pendingInvites={pendingInvites}
-          showLauncher={!isProfileDockOpen}
+showLauncher={false}
           onToggleOpen={() => setIsChatDockOpen((currentValue) => !currentValue)}
           onSearch={searchPlayers}
           onSendFriendRequest={invitePlayer}
           onRefreshFriends={refreshFriends}
           onRefreshPendingInvites={refreshPendingInvites}
+          onAcceptFriendRequest={acceptFriendRequest}
+          onRejectFriendRequest={rejectFriendRequest}
         />
+
+        <div className={classnames('dock-hub', isDockHubOpen && 'dock-hub-open')}>
+          <button className="music-dock-toggle dock-hub-toggle" type="button" onClick={() => setIsDockHubOpen((v) => !v)}>{isDockHubOpen ? '−' : '+'}</button>
+          {isDockHubOpen ? (
+            <div className="dock-hub-actions">
+              <button className="music-dock-toggle" type="button" onClick={() => setIsProfileDockOpen((v) => !v)}>P</button>
+              <button className="music-dock-toggle" type="button" onClick={() => setIsChatDockOpen((v) => !v)}>C</button>
+              <button className="music-dock-toggle" type="button" onClick={() => document.dispatchEvent(new CustomEvent('toggle-music-dock'))}>M</button>
+            </div>
+          ) : null}
+        </div>
       </div>
       {!isInMatch ? <span className="fixed bottom-1 text-sm">Project By AJ4200 c 2023</span> : null}
     </main>

--- a/ba_web/src/features/home/MusicDock.tsx
+++ b/ba_web/src/features/home/MusicDock.tsx
@@ -106,6 +106,12 @@ export function MusicDock({ tracks, isMuted, volume, showLauncher = true, onTogg
   }, [hasTracks, tracks.length]);
 
   useEffect(() => {
+    const toggle = () => setIsOpen((v) => !v);
+    document.addEventListener('toggle-music-dock', toggle);
+    return () => document.removeEventListener('toggle-music-dock', toggle);
+  }, []);
+
+  useEffect(() => {
     if (isOpen) {
       return;
     }

--- a/ba_web/src/features/home/ProfileDock.tsx
+++ b/ba_web/src/features/home/ProfileDock.tsx
@@ -30,6 +30,7 @@ type ProfileDockProps = {
   onSignOut: () => void;
   onPlayerNameChange: (value: string) => void;
   onSaveName: () => void;
+  showLauncher?: boolean;
 };
 
 export function ProfileDock({
@@ -43,6 +44,7 @@ export function ProfileDock({
   onSignOut,
   onPlayerNameChange,
   onSaveName,
+  showLauncher = true,
 }: ProfileDockProps) {
   const isConnected = Boolean(account?.sub);
   const displayName = (playerProfile?.name || account?.name || playerName || 'Player').trim() || 'Player';
@@ -85,7 +87,7 @@ export function ProfileDock({
 
   return (
     <div className={classnames('profile-dock', isOpen && 'profile-dock-open')}>
-      <button
+      {showLauncher ? <button
         className={classnames(
           'music-dock-toggle',
           'music-dock-toggle-profile',
@@ -98,7 +100,7 @@ export function ProfileDock({
       >
         <AiOutlineUser />
         {isConnected ? <span className="profile-dock-live-dot" aria-hidden="true" /> : null}
-      </button>
+      </button> : null}
 
       <section className="profile-dock-panel" aria-hidden={!isOpen}>
         <header className="profile-dock-head">


### PR DESCRIPTION
### Motivation
- The chat/friends feature was partially wired by Copilot and left the friend-request flow and UI disconnected, causing pending requests and invite UX to be unreliable. 
- Provide clear backend endpoints and normalized payloads so the frontend can reliably list, accept, and reject friend requests. 
- Improve the dock UX by grouping dock triggers into a single hub and aligning chat styling with the music/profile docks.

### Description
- Added friend-request management endpoints on the server: `GET /api/chat/friend-requests`, `POST /api/chat/friend-requests/:id/accept`, and `POST /api/chat/friend-requests/:id/reject` and normalized response fields for frontend consumption (`ba_server/src/routes/chatRoutes.js`).
- Hardened repository behavior in `chatRepository`: broadened `searchPlayers` to match on `p.name` OR `p.id`, and made `createFriendRequest` idempotent with `ON CONFLICT DO NOTHING` to avoid duplicate requests (`ba_server/src/repositories/chatRepository.js`).
- Wired frontend to the new endpoints: `refreshPendingInvites` now calls `/api/chat/friend-requests` and the app provides `acceptFriendRequest` and `rejectFriendRequest` handlers which refresh requests and friends after actions (`ba_web/src/app/page.tsx`).
- Introduced a dock hub UI that groups the three dock triggers (Profile / Chat / Music) and made individual docks support being launched from the hub by hiding their own launchers (`ba_web/src/app/page.tsx`, `ba_web/src/features/home/ProfileDock.tsx`).
- Added a custom event toggle for the music dock so the hub can toggle music with `document.dispatchEvent(new CustomEvent('toggle-music-dock'))` and added lightweight hub styling and chat-panel styling tweaks (`ba_web/src/features/home/MusicDock.tsx`, `ba_web/src/app/globals.css`).

### Testing
- No automated test suite was executed for this change, per repository AGENTS guidance to avoid broad checks by default. 
- Basic local verification steps taken: updated frontend API calls and committed the changes; no automated test failures reported because tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d3cff7e883258a9dc8860d5dce59)