### PR TITLE
Polish the settings screen experience

### DIFF
--- a/ba_web/src/app/globals.css
+++ b/ba_web/src/app/globals.css
@@ -12630,3 +12630,553 @@ h1 span:last-child {
     font-size: 0.66rem;
   }
 }
+
+/* Settings screen */
+.settings-screen {
+  width: min(96vw, 1040px);
+}
+
+.settings-screen-heading {
+  display: grid;
+  justify-items: center;
+  gap: 0.18rem;
+  text-align: center;
+}
+
+.settings-screen-heading h1 {
+  line-height: 0.95;
+}
+
+.settings-screen-heading > p {
+  max-width: 540px;
+  margin: 0.45rem 0 0;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-shadow: var(--signature-shadow);
+}
+
+.settings-screen-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.32rem 0.72rem;
+  border: 1px solid rgba(255, 255, 255, 0.46);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.42);
+  color: white;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.settings-screen-kicker svg {
+  font-size: 0.95rem;
+}
+
+.settings-shell {
+  width: min(96vw, 1040px);
+  margin-top: 1.45rem;
+  padding: 0.82rem;
+  border-radius: 24px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.12)),
+    radial-gradient(circle at 12% 0%, rgba(255, 142, 193, 0.24), transparent 32%),
+    radial-gradient(circle at 88% 8%, rgba(100, 190, 255, 0.24), transparent 34%);
+  box-shadow: 0 24px 54px rgba(0, 0, 0, 0.3), inset 0 0 0 1px rgba(255, 255, 255, 0.24);
+}
+
+.settings-shell,
+.settings-shell * {
+  text-shadow: none;
+}
+
+.settings-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.settings-save-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 38px;
+  padding: 0.4rem 0.68rem;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.55);
+  color: #171717;
+}
+
+.settings-save-status > span:last-child {
+  display: grid;
+  gap: 0.05rem;
+}
+
+.settings-save-status strong {
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+.settings-save-status small {
+  color: rgba(23, 23, 23, 0.65);
+  font-size: 0.63rem;
+}
+
+.settings-save-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #d17a2f;
+  box-shadow: 0 0 0 4px rgba(209, 122, 47, 0.14);
+}
+
+.settings-save-status-ready .settings-save-status-dot {
+  background: #29a65a;
+  box-shadow: 0 0 0 4px rgba(41, 166, 90, 0.14);
+}
+
+.settings-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(260px, 0.85fr);
+  gap: 0.72rem;
+}
+
+.settings-panel {
+  min-width: 0;
+  padding: 1rem;
+  border: 2px solid rgba(0, 0, 0, 0.58);
+  border-radius: 18px;
+  background:
+    linear-gradient(150deg, rgba(255, 255, 255, 0.82), rgba(239, 243, 250, 0.66)),
+    rgba(255, 255, 255, 0.72);
+  color: #16191f;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.14), inset 0 0 0 1px rgba(255, 255, 255, 0.58);
+}
+
+.settings-panel-experience {
+  grid-row: span 2;
+}
+
+.settings-panel-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.68rem;
+  margin-bottom: 0.85rem;
+}
+
+.settings-panel-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 2px solid rgba(0, 0, 0, 0.65);
+  border-radius: 13px;
+  color: #111;
+  font-size: 1.25rem;
+  box-shadow: 3px 4px 0 rgba(0, 0, 0, 0.72);
+  transform: rotate(-3deg);
+}
+
+.settings-panel-icon-pink {
+  background: #ffafd3;
+}
+
+.settings-panel-icon-blue {
+  background: #a8dbff;
+}
+
+.settings-panel-icon-yellow {
+  background: #ffe083;
+}
+
+.settings-panel-heading h2 {
+  margin: 0.1rem 0 0;
+  color: #14171d;
+  font-size: 1.02rem;
+  line-height: 1.1;
+}
+
+.settings-eyebrow {
+  display: block;
+  color: #5d6370;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.settings-control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.58rem;
+}
+
+.settings-control-card,
+.settings-music-card {
+  border: 1px solid rgba(18, 23, 31, 0.18);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.settings-control-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  padding: 0.72rem;
+}
+
+.settings-control-copy {
+  display: flex;
+  align-items: center;
+  gap: 0.58rem;
+  min-width: 0;
+}
+
+.settings-control-copy > svg {
+  flex: 0 0 auto;
+  color: #383f4d;
+  font-size: 1.18rem;
+}
+
+.settings-control-copy > span,
+.settings-action-button > span,
+.settings-reset-row > span {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.settings-control-copy strong,
+.settings-action-button strong,
+.settings-reset-row strong {
+  font-size: 0.76rem;
+  line-height: 1.2;
+}
+
+.settings-control-copy small,
+.settings-action-button small,
+.settings-reset-row small {
+  color: #69707d;
+  font-size: 0.64rem;
+  line-height: 1.25;
+}
+
+.settings-toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.34rem;
+  min-width: 62px;
+  padding: 0.25rem 0.45rem 0.25rem 0.27rem;
+  border: 1px solid rgba(20, 24, 31, 0.28);
+  border-radius: 999px;
+  background: #e2e5ea;
+  color: #505763;
+  font-size: 0.65rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.settings-toggle:hover,
+.settings-icon-button:hover,
+.settings-action-button:hover:not(:disabled),
+.settings-difficulty-option:hover,
+.settings-reset-row button:hover {
+  transform: translateY(-1px);
+}
+
+.settings-toggle-active {
+  background: #1d2027;
+  color: white;
+  box-shadow: 0 5px 12px rgba(0, 0, 0, 0.18);
+}
+
+.settings-toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 23px;
+  height: 23px;
+  border-radius: 999px;
+  background: white;
+  color: #1c2028;
+  font-size: 0.75rem;
+}
+
+.settings-music-card {
+  margin-top: 0.58rem;
+  padding: 0.78rem;
+}
+
+.settings-music-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.settings-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(20, 24, 31, 0.24);
+  border-radius: 10px;
+  background: #e5e8ed;
+  color: #424954;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.settings-icon-button-active {
+  background: #1d2027;
+  color: white;
+}
+
+.settings-volume-control {
+  display: grid;
+  grid-template-columns: auto minmax(90px, 1fr) 42px;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: 0.78rem;
+  padding-top: 0.72rem;
+  border-top: 1px solid rgba(20, 24, 31, 0.13);
+}
+
+.settings-volume-control > span,
+.settings-volume-control output {
+  font-size: 0.66rem;
+  font-weight: 800;
+}
+
+.settings-volume-control output {
+  padding: 0.22rem 0.3rem;
+  border-radius: 7px;
+  background: #e7eaf0;
+  text-align: center;
+}
+
+.settings-screen .settings-slider {
+  height: 6px;
+  border-radius: 999px;
+  outline: none;
+  appearance: none;
+  background: linear-gradient(to right, #20242c var(--settings-volume), #d5d9e0 var(--settings-volume));
+  cursor: pointer;
+}
+
+.settings-screen .settings-slider::-webkit-slider-thumb {
+  width: 17px;
+  height: 17px;
+  border: 3px solid white;
+  border-radius: 999px;
+  appearance: none;
+  background: #20242c;
+  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.3);
+}
+
+.settings-screen .settings-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: 3px solid white;
+  border-radius: 999px;
+  background: #20242c;
+  box-shadow: 0 2px 7px rgba(0, 0, 0, 0.3);
+}
+
+.settings-difficulty-list {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.settings-difficulty-option {
+  display: grid;
+  grid-template-columns: 28px 1fr 22px;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.57rem;
+  border: 1px solid rgba(18, 23, 31, 0.16);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.56);
+  color: #1a1d24;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+
+.settings-difficulty-option-active {
+  border-color: rgba(20, 24, 31, 0.72);
+  background: #20242c;
+  color: white;
+  box-shadow: 0 7px 15px rgba(0, 0, 0, 0.16);
+}
+
+.settings-difficulty-number {
+  color: #7c8390;
+  font-size: 0.62rem;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+}
+
+.settings-difficulty-option-active .settings-difficulty-number,
+.settings-difficulty-option-active small {
+  color: rgba(255, 255, 255, 0.64);
+}
+
+.settings-difficulty-copy {
+  display: grid;
+  gap: 0.06rem;
+}
+
+.settings-difficulty-copy strong {
+  font-size: 0.74rem;
+}
+
+.settings-difficulty-copy small {
+  color: #737a86;
+  font-size: 0.61rem;
+}
+
+.settings-difficulty-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 19px;
+  height: 19px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 0.55rem;
+  opacity: 0.75;
+}
+
+.settings-data-copy {
+  margin: -0.12rem 0 0.72rem;
+  color: #5f6672;
+  font-size: 0.67rem;
+  line-height: 1.45;
+}
+
+.settings-data-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.48rem;
+}
+
+.settings-action-button {
+  display: flex;
+  align-items: center;
+  gap: 0.52rem;
+  min-width: 0;
+  padding: 0.62rem;
+  border: 1px solid rgba(20, 24, 31, 0.24);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.66);
+  color: #1c2027;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 160ms ease, opacity 160ms ease, background 160ms ease;
+}
+
+.settings-action-button > svg {
+  flex: 0 0 auto;
+  font-size: 1.15rem;
+}
+
+.settings-action-button-primary {
+  background: #20242c;
+  color: white;
+}
+
+.settings-action-button-primary small {
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.settings-action-button:disabled {
+  opacity: 0.44;
+  cursor: not-allowed;
+}
+
+.settings-reset-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  margin-top: 0.65rem;
+  padding-top: 0.65rem;
+  border-top: 1px dashed rgba(20, 24, 31, 0.24);
+}
+
+.settings-reset-row button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.38rem 0.58rem;
+  border: 1px solid rgba(155, 48, 56, 0.32);
+  border-radius: 9px;
+  background: rgba(255, 203, 206, 0.58);
+  color: #8b2830;
+  font-size: 0.66rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+@media (max-width: 760px) {
+  .settings-screen-heading h1 {
+    font-size: clamp(3.5rem, 17vw, 5rem);
+  }
+
+  .settings-shell {
+    margin-top: 1rem;
+    padding: 0.62rem;
+  }
+
+  .settings-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-panel-experience {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .settings-screen-heading > p {
+    padding: 0 1rem;
+    font-size: 0.82rem;
+  }
+
+  .settings-toolbar {
+    align-items: stretch;
+  }
+
+  .settings-save-status {
+    max-width: 58%;
+  }
+
+  .settings-control-grid,
+  .settings-data-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-volume-control {
+    grid-template-columns: auto minmax(60px, 1fr) 42px;
+  }
+
+  .settings-reset-row {
+    align-items: flex-start;
+  }
+}

--- a/ba_web/src/features/home/SettingsScreen.tsx
+++ b/ba_web/src/features/home/SettingsScreen.tsx
@@ -1,8 +1,15 @@
-import classnames from "classnames";
-import { AiOutlineArrowLeft, AiOutlineMuted, AiOutlineSound } from "react-icons/ai";
-import type { CpuDifficulty } from "@/types/game";
-import { FaCheck, FaTimes } from "react-icons/fa";
-import { BiDownload, BiReset, BiSave } from "react-icons/bi";
+import classnames from 'classnames';
+import {
+  AiFillSetting,
+  AiOutlineArrowLeft,
+  AiOutlineMuted,
+  AiOutlineSound,
+} from 'react-icons/ai';
+import { BiDownload, BiReset, BiSave } from 'react-icons/bi';
+import { FaCheck, FaRobot, FaTimes } from 'react-icons/fa';
+import { MdAnimation, MdMusicNote, MdStorage, MdTouchApp } from 'react-icons/md';
+import type { CSSProperties } from 'react';
+import type { CpuDifficulty } from '@/types/game';
 
 type SettingsScreenProps = {
   isMusicMuted: boolean;
@@ -23,6 +30,16 @@ type SettingsScreenProps = {
   onResetPreferences: () => void;
 };
 
+const DIFFICULTY_OPTIONS: Array<{
+  value: CpuDifficulty;
+  label: string;
+  description: string;
+}> = [
+  { value: 'easy', label: 'Easy', description: 'A relaxed warm-up' },
+  { value: 'medium', label: 'Medium', description: 'A balanced battle' },
+  { value: 'hard', label: 'Hard', description: 'No mercy mode' },
+];
+
 export function SettingsScreen({
   isMusicMuted,
   isUISoundsMuted,
@@ -42,49 +59,113 @@ export function SettingsScreen({
   onResetPreferences,
 }: SettingsScreenProps) {
   return (
-    <section className="title-screen-content">
-      <h1>
-        <span>Set-</span>
-        <span>tings</span>
-      </h1>
+    <section className="title-screen-content settings-screen">
+      <div className="settings-screen-heading">
+        <span className="settings-screen-kicker">
+          <AiFillSetting aria-hidden="true" /> Tune your arena
+        </span>
+        <h1>
+          <span>Set-</span>
+          <span>tings</span>
+        </h1>
+        <p>Make every match look, sound, and play exactly your way.</p>
+      </div>
 
-      <div className="lobby-card mt-8">
-        <div className="lobby-row justify-between items-center">
+      <div className="lobby-card settings-shell">
+        <div className="settings-toolbar">
           <button className="lobby-back" type="button" onClick={onBack}>
-            <AiOutlineArrowLeft /> Back
+            <AiOutlineArrowLeft aria-hidden="true" /> Back
           </button>
-          <p className="settings-save-meta">
-            {lastSavedAtLabel ? (
-              <>
-                Last local save:{' '}
-                <span className="text-blue-500">
-                  {lastSavedAtLabel.toString()}
-                </span>
-              </>
-            ) : (
-              'No local save found yet'
-            )}
-          </p>
-        </div>
-        <div className="settings-item">
-          <p>UI Sounds</p>
-          <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onToggleUISounds}>
-            {isUISoundsMuted ? <AiOutlineMuted /> : <AiOutlineSound />}
-          </button>
-        </div>
-
-        <div className="settings-item flex flex-col space-y-4">
-          <div className="flex items-center justify-between w-full">
-            <p>Music</p>
-            <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onToggleMusic}>
-              {isMusicMuted ? <AiOutlineMuted /> : <AiOutlineSound />}
-            </button>
+          <div className={classnames('settings-save-status', hasLocalSave && 'settings-save-status-ready')}>
+            <span className="settings-save-status-dot" aria-hidden="true" />
+            <span>
+              <strong>{hasLocalSave ? 'Backup ready' : 'No backup yet'}</strong>
+              {lastSavedAtLabel && <small>Saved {lastSavedAtLabel.toString()}</small>}
+            </span>
           </div>
+        </div>
 
-          <div className="settings-item-volume flex items-center justify-between w-full">
-            <div className="flex items-center justify-between w-full">
-              <p>Volume</p>
-              <div className="settings-volume">
+        <div className="settings-layout">
+          <section className="settings-panel settings-panel-experience">
+            <div className="settings-panel-heading">
+              <span className="settings-panel-icon settings-panel-icon-pink">
+                <MdTouchApp aria-hidden="true" />
+              </span>
+              <span>
+                <span className="settings-eyebrow">Experience</span>
+                <h2>Feel the game</h2>
+              </span>
+            </div>
+
+            <div className="settings-control-grid">
+              <div className="settings-control-card">
+                <div className="settings-control-copy">
+                  <AiOutlineSound aria-hidden="true" />
+                  <span>
+                    <strong>UI sounds</strong>
+                    <small>Clicks, moves, and alerts</small>
+                  </span>
+                </div>
+                <button
+                  className={classnames('settings-toggle', !isUISoundsMuted && 'settings-toggle-active')}
+                  type="button"
+                  role="switch"
+                  aria-checked={!isUISoundsMuted}
+                  aria-label={`UI sounds ${isUISoundsMuted ? 'off' : 'on'}`}
+                  onClick={onToggleUISounds}
+                >
+                  <span className="settings-toggle-icon">
+                    {isUISoundsMuted ? <AiOutlineMuted /> : <AiOutlineSound />}
+                  </span>
+                  <span>{isUISoundsMuted ? 'Off' : 'On'}</span>
+                </button>
+              </div>
+
+              <div className="settings-control-card">
+                <div className="settings-control-copy">
+                  <MdAnimation aria-hidden="true" />
+                  <span>
+                    <strong>Motion</strong>
+                    <small>Transitions and effects</small>
+                  </span>
+                </div>
+                <button
+                  className={classnames('settings-toggle', enableAnimations && 'settings-toggle-active')}
+                  type="button"
+                  role="switch"
+                  aria-checked={enableAnimations}
+                  aria-label={`Motion ${enableAnimations ? 'on' : 'off'}`}
+                  onClick={onToggleAnimations}
+                >
+                  <span className="settings-toggle-icon">
+                    {enableAnimations ? <FaCheck /> : <FaTimes />}
+                  </span>
+                  <span>{enableAnimations ? 'On' : 'Off'}</span>
+                </button>
+              </div>
+            </div>
+
+            <div className="settings-music-card">
+              <div className="settings-music-head">
+                <div className="settings-control-copy">
+                  <MdMusicNote aria-hidden="true" />
+                  <span>
+                    <strong>Arena music</strong>
+                    <small>{isMusicMuted ? 'Muted' : 'Playing during menus and matches'}</small>
+                  </span>
+                </div>
+                <button
+                  className={classnames('settings-icon-button', !isMusicMuted && 'settings-icon-button-active')}
+                  type="button"
+                  aria-label={isMusicMuted ? 'Unmute music' : 'Mute music'}
+                  onClick={onToggleMusic}
+                >
+                  {isMusicMuted ? <AiOutlineMuted /> : <AiOutlineSound />}
+                </button>
+              </div>
+
+              <label className="settings-volume-control">
+                <span>Volume</span>
                 <input
                   className="settings-slider"
                   type="range"
@@ -92,83 +173,99 @@ export function SettingsScreen({
                   max={100}
                   step={1}
                   value={musicVolume}
+                  aria-label="Music volume"
+                  style={{ '--settings-volume': `${musicVolume}%` } as CSSProperties}
                   onChange={(event) => onMusicVolumeChange(Number(event.target.value))}
                 />
-                <span className="settings-volume-value">{musicVolume}%</span>
-              </div>
+                <output>{musicVolume}%</output>
+              </label>
+            </div>
+          </section>
+
+          <section className="settings-panel settings-panel-difficulty">
+            <div className="settings-panel-heading">
+              <span className="settings-panel-icon settings-panel-icon-blue">
+                <FaRobot aria-hidden="true" />
+              </span>
+              <span>
+                <span className="settings-eyebrow">CPU challenge</span>
+                <h2>Choose your rival</h2>
+              </span>
             </div>
 
-          </div>
-        </div>
+            <div className="settings-difficulty-list" role="radiogroup" aria-label="CPU difficulty">
+              {DIFFICULTY_OPTIONS.map((option, index) => {
+                const isActive = cpuDifficulty === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    className={classnames('settings-difficulty-option', isActive && 'settings-difficulty-option-active')}
+                    onClick={() => onCpuDifficultyChange(option.value)}
+                  >
+                    <span className="settings-difficulty-number">0{index + 1}</span>
+                    <span className="settings-difficulty-copy">
+                      <strong>{option.label}</strong>
+                      <small>{option.description}</small>
+                    </span>
+                    <span className="settings-difficulty-check" aria-hidden="true">
+                      {isActive && <FaCheck />}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
 
-        <div className="settings-item">
-          <p>Enable Motion</p>
-          <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onToggleAnimations}>
-            {enableAnimations ? <FaCheck /> : <FaTimes />}
-          </button>
-        </div>
+          <section className="settings-panel settings-panel-data">
+            <div className="settings-panel-heading">
+              <span className="settings-panel-icon settings-panel-icon-yellow">
+                <MdStorage aria-hidden="true" />
+              </span>
+              <span>
+                <span className="settings-eyebrow">Local data</span>
+                <h2>Keep your lineup safe</h2>
+              </span>
+            </div>
 
-        <div className="settings-item">
-          <p>CPU Difficulty</p>
+            <p className="settings-data-copy">
+              Store your preferences and progress on this device, then restore them whenever you need.
+            </p>
 
-          <div className={classnames("settings-tabs", "lobby-btn", "custome-shadow")}>
-            <button
-              type="button"
-              onClick={() => onCpuDifficultyChange('easy')}
-              className={classnames(
-                'settings-tab',
-                cpuDifficulty === 'easy' && 'settings-tab-active'
-              )}
-            >
-              Easy
-            </button>
+            <div className="settings-data-actions">
+              <button className="settings-action-button settings-action-button-primary" type="button" onClick={onSaveNow}>
+                <BiSave aria-hidden="true" />
+                <span>
+                  <strong>Save now</strong>
+                  <small>Update local backup</small>
+                </span>
+              </button>
+              <button
+                className="settings-action-button"
+                type="button"
+                disabled={!hasLocalSave}
+                onClick={onLoadSave}
+              >
+                <BiDownload aria-hidden="true" />
+                <span>
+                  <strong>Load save</strong>
+                  <small>{hasLocalSave ? 'Restore this device' : 'No save available'}</small>
+                </span>
+              </button>
+            </div>
 
-            <button
-              type="button"
-              onClick={() => onCpuDifficultyChange('medium')}
-              className={classnames(
-                'settings-tab',
-                cpuDifficulty === 'medium' && 'settings-tab-active'
-              )}
-            >
-              Medium
-            </button>
-
-            <button
-              type="button"
-              onClick={() => onCpuDifficultyChange('hard')}
-              className={classnames(
-                'settings-tab',
-                cpuDifficulty === 'hard' && 'settings-tab-active'
-              )}
-            >
-              Hard
-            </button>
-          </div>
-        </div>
-
-        <div className="settings-item settings-item-save">
-          <p>Local Backup</p>
-          <div className="settings-save-actions">
-            <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onSaveNow}>
-              <BiSave /> Save Now
-            </button>
-            <button
-              className={classnames("lobby-btn", "custome-shadow")}
-              type="button"
-              disabled={!hasLocalSave}
-              onClick={onLoadSave}
-            >
-              <BiDownload /> Load Save
-            </button>
-          </div>
-        </div>
-
-        <div className="settings-item">
-          <p>Preferences</p>
-          <button className={classnames("lobby-btn", "custome-shadow")} type="button" onClick={onResetPreferences}>
-            <BiReset /> Reset to Default
-          </button>
+            <div className="settings-reset-row">
+              <span>
+                <strong>Need a clean slate?</strong>
+                <small>Return audio, motion, and CPU settings to default.</small>
+              </span>
+              <button type="button" onClick={onResetPreferences}>
+                <BiReset aria-hidden="true" /> Reset
+              </button>
+            </div>
+          </section>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation

- Improve hierarchy and visual polish of the Settings screen so players can more easily manage audio, motion, CPU difficulty, and local backups.
- Surface clear state labels and accessible controls (switch/radio semantics) to make settings' effects and backup status more obvious.

### Description

- Reworked the settings UI in `ba_web/src/features/home/SettingsScreen.tsx` into three panels: `Experience`, `CPU challenge`, and `Local data`, and added the `DIFFICULTY_OPTIONS` constant for clearer option copy and descriptions.
- Added accessible roles and state indicators (`role="switch"`, `role="radio"`, `aria-checked`) and replaced simple icons with tactile toggle/radio affordances and a live volume output using the CSS variable `--settings-volume` on the slider.
- Updated visual/interaction styling in `ba_web/src/app/globals.css` with new rules for `.settings-screen`, `.settings-panel-*`, `.settings-toggle`, `.settings-difficulty-option`, `.settings-action-button`, responsive media queries, and the styled music slider.
- Kept existing settings behavior and hooks intact (same props/callbacks) while swapping the layout and adding copy, icons, and status affordances.

### Testing

- Started the Next.js dev server with `npm run dev` and confirmed the page compiled and served successfully (HTTP `200`).
- Verified `curl` to the local server returned `200` and ran `git diff --check` with no reported issues.
- Attempted to install a headless browser for an automated screenshot (`npx playwright install chromium`), but the package registry returned HTTP `403` so screenshot capture was not possible in this environment.
- Did not run automated tests, linters, or type-check commands per repository guidelines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24295464688325af600a2386958a6c)