### PR TITLE
Add PWA support, app icons, service worker, and brand lockup

### DIFF
--- a/ba_web/public/icons/baturo-arena-icon.svg
+++ b/ba_web/public/icons/baturo-arena-icon.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title description">
+  <title id="title">Baturo Arena app icon</title>
+  <desc id="description">An emerald arcade joystick and game controller inside a glowing arena badge.</desc>
+  <defs>
+    <linearGradient id="bg" x1="76" y1="38" x2="438" y2="474" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#19284a"/>
+      <stop offset="0.48" stop-color="#071522"/>
+      <stop offset="1" stop-color="#063d35"/>
+    </linearGradient>
+    <linearGradient id="arena" x1="120" y1="92" x2="394" y2="424" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#45f2ad"/>
+      <stop offset="0.5" stop-color="#10b981"/>
+      <stop offset="1" stop-color="#087f70"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="154" y1="197" x2="359" y2="372" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#243760"/>
+      <stop offset="0.55" stop-color="#101c35"/>
+      <stop offset="1" stop-color="#09111f"/>
+    </linearGradient>
+    <radialGradient id="stick" cx="36%" cy="28%" r="72%">
+      <stop stop-color="#f8fffd"/>
+      <stop offset="0.18" stop-color="#7fffd0"/>
+      <stop offset="0.5" stop-color="#12c987"/>
+      <stop offset="1" stop-color="#08745f"/>
+    </radialGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="170%">
+      <feDropShadow dx="0" dy="18" stdDeviation="14" flood-color="#000814" flood-opacity="0.68"/>
+    </filter>
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="9" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <rect x="16" y="16" width="480" height="480" rx="112" fill="url(#bg)"/>
+  <rect x="27" y="27" width="458" height="458" rx="101" fill="none" stroke="#eafff8" stroke-opacity="0.88" stroke-width="8"/>
+  <path d="M256 66 421 157v190L256 446 91 347V157L256 66Z" fill="#02131a" stroke="#b9fff0" stroke-width="10" filter="url(#shadow)"/>
+  <path d="M256 84 403 166v170l-147 88-147-88V166L256 84Z" fill="url(#arena)" stroke="#073e38" stroke-width="8"/>
+  <path d="M256 109 380 178v145l-124 74-124-74V178l124-69Z" fill="url(#bg)" stroke="#8fffd8" stroke-opacity="0.58" stroke-width="4"/>
+
+  <g fill="#dffdf4" opacity="0.92">
+    <path d="m144 161 5 13 13 5-13 5-5 13-5-13-13-5 13-5 5-13Z"/>
+    <path d="m371 141 3 8 8 3-8 3-3 8-3-8-8-3 8-3 3-8Z"/>
+    <circle cx="365" cy="350" r="5"/>
+    <circle cx="153" cy="335" r="4"/>
+  </g>
+
+  <path d="M149 229c-23 2-42 20-48 44l-17 67c-7 29 21 52 46 36l42-27h168l42 27c25 16 53-7 46-36l-17-67c-6-24-25-42-48-44l-58-5h-98l-58 5Z" fill="url(#panel)" stroke="#f0fff9" stroke-width="12" stroke-linejoin="round" filter="url(#shadow)"/>
+  <path d="M149 240c-18 2-32 15-37 36l-16 66c-3 12 8 23 19 16l45-29h192l45 29c11 7 22-4 19-16l-16-66c-5-21-19-34-37-36l-57-5H206l-57 5Z" fill="none" stroke="#35e6a2" stroke-opacity="0.55" stroke-width="5"/>
+
+  <g fill="#f7fffc" stroke="#06111d" stroke-width="6" stroke-linejoin="round">
+    <path d="M159 264h24v22h22v24h-22v22h-24v-22h-22v-24h22v-22Z"/>
+    <circle cx="344" cy="278" r="14"/>
+    <circle cx="375" cy="303" r="14"/>
+    <circle cx="313" cy="303" r="14"/>
+    <circle cx="344" cy="328" r="14"/>
+  </g>
+  <circle cx="344" cy="278" r="6" fill="#6dffd0"/>
+  <circle cx="375" cy="303" r="6" fill="#38cfff"/>
+  <circle cx="313" cy="303" r="6" fill="#f7d758"/>
+  <circle cx="344" cy="328" r="6" fill="#ff6e91"/>
+
+  <g filter="url(#shadow)">
+    <path d="M238 231h36l-5 62h-26l-5-62Z" fill="#eafff8" stroke="#07111e" stroke-width="8" stroke-linejoin="round"/>
+    <ellipse cx="256" cy="301" rx="45" ry="22" fill="#0a1426" stroke="#eafff8" stroke-width="8"/>
+    <circle cx="256" cy="191" r="49" fill="#04111e" stroke="#eafff8" stroke-width="10"/>
+    <circle cx="256" cy="191" r="37" fill="url(#stick)" stroke="#063c35" stroke-width="5"/>
+    <ellipse cx="244" cy="176" rx="10" ry="13" fill="#fff" opacity="0.8" transform="rotate(32 244 176)"/>
+  </g>
+
+  <path d="M205 363h102" stroke="#81ffda" stroke-width="10" stroke-linecap="round" filter="url(#glow)"/>
+</svg>

--- a/ba_web/public/sw.js
+++ b/ba_web/public/sw.js
@@ -1,0 +1,79 @@
+const CACHE_NAME = 'baturo-arena-v2';
+const APP_SHELL = [
+  '/',
+  '/manifest.webmanifest',
+  '/icons/baturo-arena-icon.svg',
+  '/api/app-icon?size=192',
+  '/api/app-icon?size=512',
+  '/api/app-icon?size=180',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  const isUncachedApiRequest = url.pathname.startsWith('/api/') && url.pathname !== '/api/app-icon';
+
+  if (request.method !== 'GET' || url.origin !== self.location.origin || isUncachedApiRequest) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const copy = response.clone();
+            event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.put(request, copy)));
+          }
+          return response;
+        })
+        .catch(async () => (await caches.match(request)) || (await caches.match('/')))
+    );
+    return;
+  }
+
+  const isStaticAsset =
+    url.pathname.startsWith('/_next/static/') ||
+    url.pathname.startsWith('/icons/') ||
+    url.pathname === '/api/app-icon' ||
+    ['font', 'image', 'script', 'style'].includes(request.destination);
+
+  if (!isStaticAsset) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(request).then((response) => {
+        if (response.ok) {
+          const copy = response.clone();
+          event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.put(request, copy)));
+        }
+        return response;
+      });
+    })
+  );
+});

--- a/ba_web/src/app/api/app-icon/route.tsx
+++ b/ba_web/src/app/api/app-icon/route.tsx
@@ -1,0 +1,133 @@
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
+
+export const runtime = 'edge';
+
+const SUPPORTED_SIZES = new Set([16, 32, 64, 180, 192, 512]);
+
+export function GET(request: NextRequest) {
+  const requestedSize = Number(request.nextUrl.searchParams.get('size'));
+  const size = SUPPORTED_SIZES.has(requestedSize) ? requestedSize : 512;
+  const scale = size / 512;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: 'center',
+          background: 'linear-gradient(145deg, #19284a 0%, #071522 50%, #063d35 100%)',
+          border: `${Math.max(1, 8 * scale)}px solid #eafff8`,
+          borderRadius: 112 * scale,
+          display: 'flex',
+          height: '100%',
+          justifyContent: 'center',
+          overflow: 'hidden',
+          position: 'relative',
+          width: '100%',
+        }}
+      >
+        <div
+          style={{
+            alignItems: 'center',
+            background: 'linear-gradient(145deg, #45f2ad, #087f70)',
+            border: `${Math.max(1, 10 * scale)}px solid #b9fff0`,
+            borderRadius: 108 * scale,
+            display: 'flex',
+            height: 356 * scale,
+            justifyContent: 'center',
+            position: 'relative',
+            transform: 'rotate(45deg)',
+            width: 356 * scale,
+          }}
+        >
+          <div
+            style={{
+              background: 'linear-gradient(145deg, #243760, #09111f)',
+              border: `${Math.max(1, 10 * scale)}px solid #f0fff9`,
+              borderRadius: 92 * scale,
+              display: 'flex',
+              height: 270 * scale,
+              position: 'relative',
+              transform: 'rotate(-45deg)',
+              width: 360 * scale,
+            }}
+          >
+            <div
+              style={{
+                background: '#f7fffc',
+                borderRadius: 8 * scale,
+                height: 82 * scale,
+                left: 64 * scale,
+                position: 'absolute',
+                top: 120 * scale,
+                width: 26 * scale,
+              }}
+            />
+            <div
+              style={{
+                background: '#f7fffc',
+                borderRadius: 8 * scale,
+                height: 26 * scale,
+                left: 36 * scale,
+                position: 'absolute',
+                top: 148 * scale,
+                width: 82 * scale,
+              }}
+            />
+            <div
+              style={{
+                background: 'radial-gradient(circle at 35% 28%, #ffffff 0 12%, #45f2ad 18%, #08745f 72%)',
+                border: `${Math.max(1, 9 * scale)}px solid #06111d`,
+                borderRadius: '50%',
+                height: 104 * scale,
+                left: 128 * scale,
+                position: 'absolute',
+                top: 20 * scale,
+                width: 104 * scale,
+              }}
+            />
+            <div
+              style={{
+                background: '#eafff8',
+                border: `${Math.max(1, 6 * scale)}px solid #06111d`,
+                borderRadius: 12 * scale,
+                height: 112 * scale,
+                left: 162 * scale,
+                position: 'absolute',
+                top: 102 * scale,
+                width: 36 * scale,
+              }}
+            />
+            {[
+              ['#6dffd0', 274, 116],
+              ['#38cfff', 306, 148],
+              ['#f7d758', 242, 148],
+              ['#ff6e91', 274, 180],
+            ].map(([color, left, top]) => (
+              <div
+                key={String(color)}
+                style={{
+                  background: String(color),
+                  border: `${Math.max(1, 6 * scale)}px solid #f7fffc`,
+                  borderRadius: '50%',
+                  height: 32 * scale,
+                  left: Number(left) * scale,
+                  position: 'absolute',
+                  top: Number(top) * scale,
+                  width: 32 * scale,
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      width: size,
+      height: size,
+      headers: {
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    }
+  );
+}

--- a/ba_web/src/app/globals.css
+++ b/ba_web/src/app/globals.css
@@ -12630,3 +12630,32 @@ h1 span:last-child {
     font-size: 0.66rem;
   }
 }
+
+/* Baturo Arena brand lockup */
+.title-brand-lockup {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(1rem, 2.4vw, 2rem);
+}
+
+.title-brand-icon {
+  width: clamp(5.5rem, 11vw, 8rem);
+  height: auto;
+  flex: 0 0 auto;
+  border-radius: 24%;
+  filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.38));
+}
+
+@media (max-width: 760px) {
+  .title-brand-lockup {
+    flex-direction: column;
+    gap: 0.65rem;
+  }
+
+  .title-brand-icon {
+    width: clamp(4.5rem, 22vw, 6.5rem);
+  }
+}

--- a/ba_web/src/app/layout.tsx
+++ b/ba_web/src/app/layout.tsx
@@ -1,11 +1,40 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from '@vercel/analytics/next';
 import { GlobalGameUISounds } from "@/features/home/GlobalGameUISounds";
+import { PwaRegistration } from "@/features/home/PwaRegistration";
 
 export const metadata: Metadata = {
-  title: "Baturo Arena",
-  description: "Baturo Arena is a multiplayer hub with online,local and CPU play across multiple games.",
+  applicationName: "Baturo Arena",
+  title: {
+    default: "Baturo Arena",
+    template: "%s | Baturo Arena",
+  },
+  description: "Play online, local, CPU, and solo games together in one arcade arena.",
+  manifest: "/manifest.webmanifest",
+  icons: {
+    icon: [
+      { url: "/icons/baturo-arena-icon.svg", type: "image/svg+xml", sizes: "any" },
+      { url: "/api/app-icon?size=32", sizes: "32x32", type: "image/png" },
+      { url: "/api/app-icon?size=16", sizes: "16x16", type: "image/png" },
+    ],
+    shortcut: [{ url: "/api/app-icon?size=64", sizes: "64x64", type: "image/png" }],
+    apple: [{ url: "/api/app-icon?size=180", sizes: "180x180", type: "image/png" }],
+  },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Baturo Arena",
+  },
+  formatDetection: { telephone: false },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#0c584a",
+  colorScheme: "dark",
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({
@@ -16,6 +45,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="ba-root-scroll">
       <body>
+        <PwaRegistration />
         <GlobalGameUISounds
           clickSoundSrc="/music/ui/ui-click.mp3"
           volume={0.2}

--- a/ba_web/src/app/manifest.ts
+++ b/ba_web/src/app/manifest.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    id: '/',
+    name: 'Baturo Arena',
+    short_name: 'Baturo',
+    description: 'Play online, local, CPU, and solo games together in one arcade arena.',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    background_color: '#071522',
+    theme_color: '#0c584a',
+    orientation: 'any',
+    categories: ['games', 'entertainment'],
+    icons: [
+      {
+        src: '/api/app-icon?size=192',
+        sizes: '192x192',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/api/app-icon?size=512',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'any',
+      },
+      {
+        src: '/api/app-icon?size=512',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+  };
+}

--- a/ba_web/src/features/home/MainMenu.tsx
+++ b/ba_web/src/features/home/MainMenu.tsx
@@ -25,11 +25,21 @@ export function MainMenu({
   return (
     <section className="title-screen-content">
       <div className="title-board-card title-board-card-hero">
-        <h1>
-          <span className="title-main-first">Baturo</span>
-          <span className="title-main-dash">-</span>
-          <span className="title-main-last">Arena</span>
-        </h1>
+        <div className="title-brand-lockup">
+          <img
+            className="title-brand-icon"
+            src="/icons/baturo-arena-icon.svg"
+            alt=""
+            width="128"
+            height="128"
+            aria-hidden="true"
+          />
+          <h1>
+            <span className="title-main-first">Baturo</span>
+            <span className="title-main-dash">-</span>
+            <span className="title-main-last">Arena</span>
+          </h1>
+        </div>
       </div>
 
       <motion.div

--- a/ba_web/src/features/home/PwaRegistration.tsx
+++ b/ba_web/src/features/home/PwaRegistration.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function PwaRegistration() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) {
+      return;
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      void navigator.serviceWorker.getRegistrations().then((registrations) => {
+        registrations.forEach((registration) => void registration.unregister());
+      });
+      return;
+    }
+
+    const registerServiceWorker = () => {
+      void navigator.serviceWorker.register('/sw.js', { scope: '/' });
+    };
+
+    if (document.readyState === 'complete') {
+      registerServiceWorker();
+      return;
+    }
+
+    window.addEventListener('load', registerServiceWorker, { once: true });
+    return () => window.removeEventListener('load', registerServiceWorker);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
### Motivation
- Provide PWA support with platform icons and an installable web manifest to improve offline/load resilience and native-like installability. 
- Surface a dedicated Baturo Arena app icon and brand lockup in the title screen to strengthen brand presentation.
- Cache static shell assets and app icon responses to enable faster navigations and offline access.

### Description
- Added a new SVG app icon at `public/icons/baturo-arena-icon.svg` and a server-side dynamic icon generator at `src/app/api/app-icon/route.tsx` that returns PNG images at supported sizes with long-lived cache headers. 
- Introduced a web manifest route `src/app/manifest.ts` and wired manifest/icons into the app metadata in `src/app/layout.tsx`. 
- Implemented a service worker `public/sw.js` with install/activate handlers and a fetch handler that caches the app shell and static assets while excluding uncached API endpoints. 
- Added a client component `src/features/home/PwaRegistration.tsx` that registers the service worker in production and unregisters service workers during development, and integrated it into the root layout. 
- Updated the home title UI in `src/features/home/MainMenu.tsx` to display the brand icon alongside the title, and added corresponding styles in `src/app/globals.css` for the brand lockup and responsive behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2429f785c883259b0d404ff033ad68)